### PR TITLE
Files functions update

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -5,12 +5,17 @@
     - [copy_file](#copy_file)  
     - [directory_listing](#directory_listing)  
     - [exists](#exists)  
+    - [exists_unsafe](#exists_unsafe)  
     - [file_content](#file_content)  
+    - [file_copy](#file_copy)  
+    - [file_copy_unsafe](#file_copy_unsafe)  
     - [file_delete](#file_delete)  
     - [file_move](#file_move)  
+    - [file_move_unsafe](#file_move_unsafe)  
     - [file_unlock](#file_unlock)  
     - [full_path](#full_path)  
     - [get_parent](#get_parent)  
+    - [home](#home)  
     - [is_file](#is_file)  
     - [is_folder](#is_folder)  
     - [meta_data](#meta_data)  
@@ -56,12 +61,7 @@ Aborts execution with an error message. This error message will be shown to the 
 
 `copy_file(Node file, String folder_path, [String name]=nil): Bool`  
   
-Copies the given `file` to the specified `folder_path`.  
-Optionally a new name can be specified for the file, if none is specified the original name is used.  
-  
-If the target file already exists, the operation will not succeed.  
-  
-Returns whether the operation was successful.
+⚠️ DEPRECATED: This function will be removed in v2.0.0. See [file_copy](#file_copy)
 ### directory_listing
 
 `directory_listing(Node folder, [String filter_type]='all'): Node[]`  
@@ -78,11 +78,41 @@ Optionally a second argument can be provided to filter out files or folders:
 Returns whether a file or directory exists.  
 Optionally the name of a file can be specified as a second argument, in which case the first argument will be  
 assumed to be directory. The function will return whether the file exists in the directory.
+### exists_unsafe
+
+`exists_unsafe(String path): Bool`  
+  
+Returns whether a file or directory exists. The expected path must be from the server root directory (e.g. `/alice/files/example.txt`).  
+For most cases it is recommended to use the function [exists()](#exists).
 ### file_content
 
 `file_content(Node node): String|nil`  
   
 Returns the string content of the file. If the node is a directory or the file does not exist, `nil` is returned.
+### file_copy
+
+`file_copy(Node file, String folder_path, [String name]=nil): Node|nil`  
+  
+Copies the given `file` to the specified `folder_path`.  
+Optionally a new name can be specified for the file, if none is specified the original name is used.  
+  
+If the target file already exists, the operation will not succeed.  
+  
+Returns the resulting file node, or `nil` if the operation failed.
+### file_copy_unsafe
+
+`file_copy_unsafe(Node file, String folder_path, [String name]=nil): Bool`  
+  
+Unsafe version of [`file_copy`](#file_copy).  
+This function expects an absolute path from the server root (not from the users home folder). This means that files can be copied to locations which the user running the action does not have access to.  
+This function performs no validation on the given path and does not check for file overwrites (overwrite handling is left up to the Nextcloud server implementation).  
+  
+⚠️ Use of this function is strongly discouraged as it offers no safeguards against data-loss and carries potential security concerns.  
+  
+```lua  
+local file = get_input_files()[1]  
+file_copy_unsafe(file, "alice/files/inbox", "message.txt")  
+```
 ### file_delete
 
 `file_delete(Node node, [Bool success_if_not_found]=true): Bool`  
@@ -101,7 +131,21 @@ If no new_name is given, the old name is used.
   
 If the target file already exists, the operation will not succeed.  
   
-Returns the resulting file, or nil if the operation failed.
+Returns the resulting file, or `nil` if the operation failed.
+### file_move_unsafe
+
+`file_move_unsafe(Node file, [String folder = nil], [String new_name = nil]): Node|null`  
+  
+Unsafe version of [`file_move`](#file_move).  
+This function expects an absolute path from the server root (not from the users home folder). This means that files can be copied to locations which the user running the action does not have access to.  
+This function performs no validation on the given path and does not check for file overwrites (overwrite handling is left up to the Nextcloud server implementation).  
+  
+⚠️ Use of this function is strongly discouraged as it offers no safeguards against data-loss and carries potential security concerns.  
+  
+```lua  
+local file = get_input_files()[1]  
+file_move_unsafe(file, "alice/files/inbox", "message.txt")  
+```
 ### file_unlock
 
 `file_unlock(Node node, [Bool success_if_not_found]=true): Bool`  
@@ -126,6 +170,11 @@ Returns the parent folder for the given file or directory.
 The root of the "filesystem" is considered to be the home directory of the user who is running the script. When attempting to get the parent of the root directory, the root directory is returned.  
   
 If the given file cannot be found, `nil` is returned.
+### home
+
+`home(): Node`  
+  
+Returns the node object for the user's home directory.
 ### is_file
 
 `is_file(Node node): Bool`  
@@ -164,7 +213,7 @@ Returns whether a node object represents a real file or folder.
 
 `root(): Node`  
   
-Returns the node object for the user's root directory.
+⚠️ DEPRECATED: See [home](#home)
 ## Input
 ### get_input
 

--- a/lib/Interpreter/FunctionProvider.php
+++ b/lib/Interpreter/FunctionProvider.php
@@ -3,15 +3,20 @@
 namespace OCA\FilesScripts\Interpreter;
 
 use OCA\FilesScripts\Interpreter\Functions\Error\Abort;
+use OCA\FilesScripts\Interpreter\Functions\Error\Log;
 use OCA\FilesScripts\Interpreter\Functions\Files\Copy_File;
 use OCA\FilesScripts\Interpreter\Functions\Files\Directory_Listing;
 use OCA\FilesScripts\Interpreter\Functions\Files\Exists;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Content;
+use OCA\FilesScripts\Interpreter\Functions\Files\File_Copy;
+use OCA\FilesScripts\Interpreter\Functions\Files\File_Copy_Unsafe;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Delete;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Move;
+use OCA\FilesScripts\Interpreter\Functions\Files\File_Move_Unsafe;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Unlock;
 use OCA\FilesScripts\Interpreter\Functions\Files\Full_Path;
 use OCA\FilesScripts\Interpreter\Functions\Files\Get_Parent;
+use OCA\FilesScripts\Interpreter\Functions\Files\Home;
 use OCA\FilesScripts\Interpreter\Functions\Files\Is_File;
 use OCA\FilesScripts\Interpreter\Functions\Files\Is_Folder;
 use OCA\FilesScripts\Interpreter\Functions\Files\Meta_Data;
@@ -34,7 +39,6 @@ use OCA\FilesScripts\Interpreter\Functions\Util\Format_Date_Time;
 use OCA\FilesScripts\Interpreter\Functions\Util\Format_Price;
 use OCA\FilesScripts\Interpreter\Functions\Util\Http_Request;
 use OCA\FilesScripts\Interpreter\Functions\Util\Json;
-use OCA\FilesScripts\Interpreter\Functions\Util\Log;
 use OCA\FilesScripts\Interpreter\Functions\Util\Sort;
 use OCA\FilesScripts\Interpreter\Functions\Util\Wait;
 
@@ -64,20 +68,24 @@ class FunctionProvider implements IFunctionProvider {
 		Html_To_Pdf $f19,
 		Mustache $f20,
 		Sort $f21,
-		Json $f22,
-		Http_Request $f23,
-		Pdf_Pages $f24,
-		File_Delete $f25,
-		Node_Exists $f26,
-		Pdf_Page_Count $f27,
-		Format_Price $f28,
+		Json             $f22,
+		Http_Request     $f23,
+		Pdf_Pages        $f24,
+		File_Delete      $f25,
+		Node_Exists      $f26,
+		Pdf_Page_Count   $f27,
+		Format_Price     $f28,
 		Create_Date_Time $f29,
 		Format_Date_Time $f30,
-		File_Unlock $f31,
-		File_Move $f32,
-		Wait $f33,
-		Log $f34,
-		For_Each $f35
+		File_Unlock      $f31,
+		File_Move        $f32,
+		Wait             $f33,
+		Log              $f34,
+		For_Each         $f35,
+		File_Copy $f36,
+		File_Copy_Unsafe $f37,
+		File_Move_Unsafe $f38,
+		Home $f39
 	) {
 		$this->functions = func_get_args();
 	}

--- a/lib/Interpreter/FunctionProvider.php
+++ b/lib/Interpreter/FunctionProvider.php
@@ -7,6 +7,7 @@ use OCA\FilesScripts\Interpreter\Functions\Error\Log;
 use OCA\FilesScripts\Interpreter\Functions\Files\Copy_File;
 use OCA\FilesScripts\Interpreter\Functions\Files\Directory_Listing;
 use OCA\FilesScripts\Interpreter\Functions\Files\Exists;
+use OCA\FilesScripts\Interpreter\Functions\Files\Exists_Unsafe;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Content;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Copy;
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Copy_Unsafe;
@@ -85,7 +86,8 @@ class FunctionProvider implements IFunctionProvider {
 		File_Copy $f36,
 		File_Copy_Unsafe $f37,
 		File_Move_Unsafe $f38,
-		Home $f39
+		Home $f39,
+		Exists_Unsafe $f40
 	) {
 		$this->functions = func_get_args();
 	}

--- a/lib/Interpreter/Functions/Files/Copy_File.php
+++ b/lib/Interpreter/Functions/Files/Copy_File.php
@@ -2,41 +2,36 @@
 
 namespace OCA\FilesScripts\Interpreter\Functions\Files;
 
-use OCA\FilesScripts\Interpreter\RegistrableFunction;
+use Psr\Log\LoggerInterface;
 
 /**
  * `copy_file(Node file, String folder_path, [String name]=nil): Bool`
  *
- * Copies the given `file` to the specified `folder_path`.
- * Optionally a new name can be specified for the file, if none is specified the original name is used.
- *
- * If the target file already exists, the operation will not succeed.
- *
- * Returns whether the operation was successful.
+ * ⚠️ DEPRECATED: This function will be removed in v2.0.0. See [file_copy](#file_copy)
  */
-class Copy_File extends RegistrableFunction {
+class Copy_File extends File_Copy {
+
+	private LoggerInterface $logger;
+
+	public function __construct(LoggerInterface $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * TODO: Remove this function for v2 and add return to File_Copy function signature.
+	 *
+	 * @param $file
+	 * @param $folderPath
+	 * @param $name
+	 * @return bool
+	 * @throws \OCA\FilesScripts\Interpreter\AbortException
+	 */
 	public function run(
 		$file = null,
 		$folderPath = null,
 		$name = null
-	): bool {
-		$fileNode = $this->getFile($this->getPath($file));
-		$folderNode = $this->getFolder($folderPath);
-
-		if (!$fileNode) {
-			return false;
-		}
-		if (!$folderNode || $folderNode->nodeExists($name)) {
-			return false;
-		}
-
-		$name = $name ?: $fileNode->getName();
-		$path = $folderNode->getPath() . '/' . $name;
-		try {
-			$fileNode->copy($path);
-		} catch (\Exception $exception) {
-			return false;
-		}
-		return true;
+	) {
+		$this->logger->warning("[File actions]: Use of deprecated function `copy_file()`, please use `file_copy()` instead.");
+		return (bool) parent::run($file, $folderPath, $name);
 	}
 }

--- a/lib/Interpreter/Functions/Files/Exists.php
+++ b/lib/Interpreter/Functions/Files/Exists.php
@@ -19,7 +19,7 @@ class Exists extends RegistrableFunction {
 
 		$path = $this->getPath($node);
 		if ($fileName === null) {
-			return $this->getRootFolder()->nodeExists($path);
+			return $this->getHomeFolder()->nodeExists($path);
 		}
 
 		$folderNode = $this->getFolder($path);

--- a/lib/Interpreter/Functions/Files/Exists_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/Exists_Unsafe.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+use OCP\Files\IRootFolder;
+
+/**
+ * `exists_unsafe(String path): Bool`
+ *
+ * Returns whether a file or directory exists. The expected path must be from the server root directory (e.g. `/alice/files/example.txt`).
+ * For most cases it is recommended to use the function [exists()](#exists).
+ */
+class Exists_Unsafe extends RegistrableFunction {
+	private IRootFolder $root;
+
+	public function __construct(IRootFolder $root) {
+		$this->root = $root;
+	}
+
+	public function run($path = null): bool {
+		if (!$path) {
+			return false;
+		}
+
+		return $this->root->nodeExists($path);
+	}
+}

--- a/lib/Interpreter/Functions/Files/File_Copy.php
+++ b/lib/Interpreter/Functions/Files/File_Copy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+
+/**
+ * `file_copy(Node file, String folder_path, [String name]=nil): Node|nil`
+ *
+ * Copies the given `file` to the specified `folder_path`.
+ * Optionally a new name can be specified for the file, if none is specified the original name is used.
+ *
+ * If the target file already exists, the operation will not succeed.
+ *
+ * Returns the resulting file node, or `nil` if the operation failed.
+ */
+class File_Copy extends File_Copy_Unsafe {
+	public function run(
+		$file = null,
+		$folderPath = null,
+		$name = null
+	) {
+		$fileNode = $this->getFile($this->getPath($file));
+		$folderNode = $this->getFolder($folderPath);
+		if (!$fileNode || !$folderNode) {
+			return null;
+		}
+
+		$newName = $name ?: $fileNode->getName();
+		if ($folderNode->nodeExists($newName)) {
+			return null;
+		}
+
+		return parent::run($file, $folderNode->getPath(), $name);
+	}
+}

--- a/lib/Interpreter/Functions/Files/File_Copy_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/File_Copy_Unsafe.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+
+/**
+ * `file_copy_unsafe(Node file, String folder_path, [String name]=nil): Bool`
+ *
+ * Unsafe version of `copy_file`.
+ * This function expects an absolute path from the server root (not from the users home folder). This means that files can be copied to locations which the user running the action does not have access to.
+ * This function performs no validation on the given path and does not check for file overwrites (overwrite handling is left up to the Nextcloud server implementation).
+ *
+ * ⚠️ Use of this function is strongly discouraged as it offers no safeguards against data-loss and carries potential security concerns.
+ *
+ * ```lua
+ * local file = get_input_files()[1]
+ * file_copy_unsafe(file, "alice/files/inbox", "message.txt")
+ * ```
+ */
+class File_Copy_Unsafe extends RegistrableFunction {
+	public function run(
+		$file = null,
+		$folderPath = null,
+		$name = null
+	) {
+		$fileNode = $this->getFile($this->getPath($file));
+		if (!$fileNode) {
+			return false;
+		}
+
+		$name = $name ?: $fileNode->getName();
+		$path = $folderPath . '/' . $name;
+
+		try {
+			$newFile = $fileNode->copy($path);
+			return $this->getNodeData($newFile);
+		} catch (\Exception $exception) {
+			return null;
+		}
+	}
+}

--- a/lib/Interpreter/Functions/Files/File_Copy_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/File_Copy_Unsafe.php
@@ -5,9 +5,9 @@ namespace OCA\FilesScripts\Interpreter\Functions\Files;
 use OCA\FilesScripts\Interpreter\RegistrableFunction;
 
 /**
- * `file_copy_unsafe(Node file, String folder_path, [String name]=nil): Bool`
+ * `file_copy_unsafe(Node file, String folder_path, [String name]=nil): Node|nil`
  *
- * Unsafe version of `copy_file`.
+ * Unsafe version of [`file_copy`](#file_copy).
  * This function expects an absolute path from the server root (not from the users home folder). This means that files can be copied to locations which the user running the action does not have access to.
  * This function performs no validation on the given path and does not check for file overwrites (overwrite handling is left up to the Nextcloud server implementation).
  *

--- a/lib/Interpreter/Functions/Files/File_Move.php
+++ b/lib/Interpreter/Functions/Files/File_Move.php
@@ -3,7 +3,6 @@
 namespace OCA\FilesScripts\Interpreter\Functions\Files;
 
 use Exception;
-use OCA\FilesScripts\Interpreter\RegistrableFunction;
 use OCP\Files\IRootFolder;
 
 /**
@@ -15,9 +14,9 @@ use OCP\Files\IRootFolder;
  *
  * If the target file already exists, the operation will not succeed.
  *
- * Returns the resulting file, or nil if the operation failed.
+ * Returns the resulting file, or `nil` if the operation failed.
  */
-class File_Move extends RegistrableFunction {
+class File_Move extends File_Move_Unsafe {
 	private IRootFolder $rootFolder;
 
 	public function __construct(IRootFolder $rootFolder) {
@@ -43,9 +42,8 @@ class File_Move extends RegistrableFunction {
 		}
 
 		try {
-			$destination = $this->rootFolder->getRelativePath($folderNode->getPath()) . "/$newName";
-			$newFileNode = $fileNode->move($destination);
-			return $this->getNodeData($newFileNode);
+			$destination = $this->rootFolder->getRelativePath($folderNode->getPath());
+			return parent::run($file, $destination, $newName);
 		} catch (Exception $e) {
 			return null;
 		}

--- a/lib/Interpreter/Functions/Files/File_Move_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/File_Move_Unsafe.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+use Throwable;
+
+/**
+ * `file_move_unsafe(Node file, [String folder = nil], [String new_name = nil]): Node|null`
+ *
+ * Unsafe version of `file_move`.
+ * This function expects an absolute path from the server root (not from the users home folder). This means that files can be copied to locations which the user running the action does not have access to.
+ * This function performs no validation on the given path and does not check for file overwrites (overwrite handling is left up to the Nextcloud server implementation).
+ *
+ * Note: If
+ *
+ * ⚠️ Use of this function is strongly discouraged as it offers no safeguards against data-loss and carries potential security concerns.
+ *
+ * ```lua
+ * local file = get_input_files()[1]
+ * file_move_unsafe(file, "alice/files/inbox", "message.txt")
+ * ```
+ */
+class File_Move_Unsafe extends RegistrableFunction {
+
+	public function run(
+		$file = null,
+		$folderPath = null,
+		$newName = null
+	): ?array {
+		$fileNode = $this->getFile($this->getPath($file));
+		if (!$fileNode) {
+			return null;
+		}
+
+		$newName = $newName ?: $fileNode->getName();
+		$destination = $folderPath . '/' . $newName;
+
+		try {
+			$newFileNode = $fileNode->move($destination);
+			return $this->getNodeData($newFileNode);
+		} catch (Throwable $e) {
+			return null;
+		}
+	}
+}

--- a/lib/Interpreter/Functions/Files/File_Move_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/File_Move_Unsafe.php
@@ -8,11 +8,9 @@ use Throwable;
 /**
  * `file_move_unsafe(Node file, [String folder = nil], [String new_name = nil]): Node|null`
  *
- * Unsafe version of `file_move`.
+ * Unsafe version of [`file_move`](#file_move).
  * This function expects an absolute path from the server root (not from the users home folder). This means that files can be copied to locations which the user running the action does not have access to.
  * This function performs no validation on the given path and does not check for file overwrites (overwrite handling is left up to the Nextcloud server implementation).
- *
- * Note: If
  *
  * ⚠️ Use of this function is strongly discouraged as it offers no safeguards against data-loss and carries potential security concerns.
  *

--- a/lib/Interpreter/Functions/Files/Full_Path.php
+++ b/lib/Interpreter/Functions/Files/Full_Path.php
@@ -17,7 +17,7 @@ class Full_Path extends RegistrableFunction {
 	public function run($node = null): ?string {
 		$node = $this->getNode($this->getPath($node));
 		try {
-			return $node ? $this->getRootFolder()->getRelativePath($node->getPath()) : null;
+			return $node ? $this->getHomeFolder()->getRelativePath($node->getPath()) : null;
 		} catch (NotFoundException $e) {
 			return null;
 		}

--- a/lib/Interpreter/Functions/Files/Get_Parent.php
+++ b/lib/Interpreter/Functions/Files/Get_Parent.php
@@ -21,8 +21,8 @@ class Get_Parent extends RegistrableFunction {
 			return null;
 		}
 		try {
-			if ($node->getId() === $this->getRootFolder()->getId()) {
-				$node = $this->getRootFolder();
+			if ($node->getId() === $this->getHomeFolder()->getId()) {
+				$node = $this->getHomeFolder();
 			}
 		} catch (InvalidPathException|NotFoundException $e) {
 			return null;

--- a/lib/Interpreter/Functions/Files/Home.php
+++ b/lib/Interpreter/Functions/Files/Home.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+
+/**
+ * `home(): Node`
+ *
+ * Returns the node object for the user's home directory.
+ */
+class Home extends RegistrableFunction {
+	public function run($node = null): array {
+		return $this->getNodeData($this->getHomeFolder());
+	}
+}

--- a/lib/Interpreter/Functions/Files/Root.php
+++ b/lib/Interpreter/Functions/Files/Root.php
@@ -3,14 +3,23 @@
 namespace OCA\FilesScripts\Interpreter\Functions\Files;
 
 use OCA\FilesScripts\Interpreter\RegistrableFunction;
+use Psr\Log\LoggerInterface;
 
 /**
  * `root(): Node`
  *
- * Returns the node object for the user's root directory.
+ * ⚠️ DEPRECATED: See [home](#home)
  */
 class Root extends RegistrableFunction {
+
+	private LoggerInterface $logger;
+
+	public function __construct(LoggerInterface $logger) {
+		$this->logger = $logger;
+	}
+
 	public function run($node = null): array {
-		return $this->getNodeData($this->getRootFolder());
+		$this->logger->warning("[File actions]: Use of deprecated function `root()`, please use `home()` instead. In future API versions the `root()` may be repurposed and break your scripts.");
+		return $this->getNodeData($this->getHomeFolder());
 	}
 }

--- a/lib/Interpreter/RegistrableFunction.php
+++ b/lib/Interpreter/RegistrableFunction.php
@@ -31,7 +31,7 @@ abstract class RegistrableFunction {
 		return $this->context;
 	}
 
-	final protected function getRootFolder(): Folder {
+	final protected function getHomeFolder(): Folder {
 		return $this->getContext()->getRoot();
 	}
 
@@ -45,7 +45,7 @@ abstract class RegistrableFunction {
 		}
 
 		try {
-			return $this->getRootFolder()->get($path);
+			return $this->getHomeFolder()->get($path);
 		} catch (NotFoundException $e) {
 			return null;
 		}
@@ -74,7 +74,7 @@ abstract class RegistrableFunction {
 			$id = null;
 		}
 
-		$root = $this->getRootFolder();
+		$root = $this->getHomeFolder();
 		$path = '';
 		$name = '/';
 		if ($id !== $root->getId()) {


### PR DESCRIPTION
Addresses: #9 

This PR makes some changes to the `Files` functions:

Additions:  
* `file_copy_unsafe`: allows files to be copied to any path from the server root.
* `file_move_unsafe`: allows files to be moved to any path from the server root.
* `exists_unsafe`: allows to check if a file exists from any path from the server root

Changes: (deprecated functions are not yet removed)  
* `root()` is renamed to `home()` (root may be used later on to fetch the server root)
* `copy_file` is renamed to `file_copy` for consitency with other functions