### PR TITLE
Implement different script-input types

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,6 +11,7 @@ return [
 	'routes' => [
 		['name' => 'script#run', 'url' => '/run/{id}', 'verb' => 'POST'],
 		['name' => 'script#getInputs', 'url' => '/scripts/{id}/inputs', 'verb' => 'GET'],
+		['name' => 'script_input#getByScriptId', 'url' => '/script_inputs/{scriptId}', 'verb' => 'GET'],
 		['name' => 'script_input#createAll', 'url' => '/script_inputs/{scriptId}', 'verb' => 'POST'],
 		['name' => 'settings#modify', 'url' => '/settings', 'verb' => 'POST'],
 	]

--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -12,11 +12,19 @@ A common use for this input option is to select a location where to save the fil
 ### Input values
 Any number of additional input values can be added in the script-creation view. These are made available to the scripting API via the [`get_input()`](Functions.md#get_input) function. 
 
+By default, input types are text-fields where the user may type in the value. However other, more restrictive input types may be used:
+
+- **Checkbox** allows for a boolean (`true`/`false`)  input from the user
+- **Multiselect** allows the user to select from a set of pre-determined inputs.
+- **File-picker** allows the user to choose a document from their Nextcloud files. 
+
+Note: to allow a user to pick a folder the `httpd/unix-directory` mimetype must be added to the filepick options.
+
 ### Required fields
 User input fields will always be optional: the action may still be triggered even if the user did not input anything. However, additional checks can be performed on the script itself, and an [error](Functions.md#abort) may be returned to the user if any required fields were not (correctly) filled.
 
 ```lua
-local file_name = get_input().name
+local file_name = get_input('file_name')
 if (not file_name or string.len(file_name) == 0) then
   abort('File name was not filled in.')
 end 
@@ -65,4 +73,4 @@ Actions can also be configured to work with Nextcloud's automated flows.
 
 When running a script from a flow `get_input_files()` will only contain the file that triggered the flow, and `get_target_folder()` will be the folder containing the file. 
 
-Additionally, for "file rename" and "file copy" events, the previous file node's path can be accessed with: `get_input().old_node_path`
+Additionally, for "file rename" and "file copy" events, the previous file's path can be accessed with: `get_input('old_node_path')`

--- a/lib/Controller/ScriptController.php
+++ b/lib/Controller/ScriptController.php
@@ -168,9 +168,15 @@ class ScriptController extends Controller {
 			$fileNodes[$n++] = $userFolder->get($path);
 		}
 
-		$scriptInputs = [];
+		$groupedInputs = [];
 		foreach ($inputs as $input) {
-			$scriptInputs[$input['name']] = $input['value'] ?? null;
+			$groupedInputs[$input['name']] = $input;
+		}
+
+		$scriptInputs = $this->scriptInputMapper->findAllByScriptId($id);
+		foreach ($scriptInputs as $scriptInput) {
+			$value = $groupedInputs[$scriptInput->getName()]['value'] ?? '';
+			$scriptInput->setValue($value);
 		}
 
 		$context = new Context($this->luaProvider->createLua(), $userFolder, $scriptInputs, $fileNodes, $outputDirectory);

--- a/lib/Controller/ScriptInputController.php
+++ b/lib/Controller/ScriptInputController.php
@@ -7,6 +7,7 @@ use OCA\FilesScripts\Db\ScriptInputMapper;
 use OCA\FilesScripts\Db\ScriptMapper;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\DB\Exception;
@@ -38,6 +39,13 @@ class ScriptInputController extends Controller {
 		return new JSONResponse([], Http::STATUS_NOT_IMPLEMENTED);
 	}
 
+	/**
+	 * @NoAdminRequired
+	 */
+	public function getByScriptId($scriptId): Response {
+		return new DataResponse($this->scriptInputMapper->findAllByScriptId($scriptId));
+	}
+
 	public function createAll(int $scriptId, $scriptInputs): Response {
 		$script = $this->scriptMapper->find($scriptId);
 		if (!$script) {
@@ -49,6 +57,7 @@ class ScriptInputController extends Controller {
 			$scriptInput = new ScriptInput();
 			$scriptInput->setName($scriptInputArr['name']);
 			$scriptInput->setDescription($scriptInputArr['description']);
+			$scriptInput->setScriptOptions($scriptInputArr['options']);
 			$scriptInput->setScriptId($scriptId);
 
 			try {
@@ -59,25 +68,6 @@ class ScriptInputController extends Controller {
 		}
 
 		return new JSONResponse();
-	}
-
-	public function create(string $name, string $description, int $scriptId): Response {
-		$script = $this->scriptMapper->find($scriptId);
-		if (!$script) {
-			return new JSONResponse(['error' => $this->l->t('Failed to create the action variables.')], Http::STATUS_NOT_FOUND);
-		}
-		$scriptInput = new ScriptInput();
-		$scriptInput->setName($name);
-		$scriptInput->setDescription($description);
-		$scriptInput->setScriptId($scriptId);
-
-		try {
-			$this->scriptInputMapper->insert($scriptInput);
-		} catch (Exception $e) {
-			return new JSONResponse(['error' => $this->l->t('Failed to create the action variables.')], Http::STATUS_BAD_REQUEST);
-		}
-
-		return new JSONResponse($script);
 	}
 
 	/**

--- a/lib/Db/ScriptInput.php
+++ b/lib/Db/ScriptInput.php
@@ -22,7 +22,7 @@ class ScriptInput extends Entity implements JsonSerializable {
 	protected ?int $scriptId = null;
 	protected ?string $options = null;
 
-	protected ?string $value = null;
+	protected $value = null;
 
 	public function jsonSerialize(): array {
 		return [
@@ -57,11 +57,11 @@ class ScriptInput extends Entity implements JsonSerializable {
 		}
 	}
 
-	public function getValue(): ?string {
+	public function getValue() {
 		return $this->value;
 	}
 
-	public function setValue(?string $value): void {
+	public function setValue($value): void {
 		$this->value = $value;
 	}
 }

--- a/lib/Db/ScriptInput.php
+++ b/lib/Db/ScriptInput.php
@@ -4,6 +4,7 @@ namespace OCA\FilesScripts\Db;
 
 use JsonSerializable;
 use OCP\AppFramework\Db\Entity;
+use Throwable;
 
 /**
  * @method setName(string $name)
@@ -12,11 +13,14 @@ use OCP\AppFramework\Db\Entity;
  * @method string getDescription()
  * @method setScriptId(int $scriptId)
  * @method string getScriptId()
+ * @method setOptions(string $options)
+ * @method string getOptions()
  */
 class ScriptInput extends Entity implements JsonSerializable {
 	protected ?string $name = null;
 	protected ?string $description = null;
 	protected ?int $scriptId = null;
+	protected ?string $options = null;
 
 	public function jsonSerialize(): array {
 		return [
@@ -24,6 +28,30 @@ class ScriptInput extends Entity implements JsonSerializable {
 			'name' => $this->name,
 			'description' => $this->description,
 			'scriptId' => $this->scriptId,
+			'options' => $this->getScriptOptions()
 		];
+	}
+
+	/**
+	 * @param string|array $options
+	 */
+	public function setScriptOptions($options): void {
+		if (is_array($options)) {
+			try {
+				$options = json_encode($options, JSON_THROW_ON_ERROR);
+			} catch (Throwable $e) {
+				$options = '';
+			}
+		}
+
+		$this->setOptions($options);
+	}
+
+	public function getScriptOptions(): array {
+		try {
+			return json_decode($this->getOptions(), true, 3, JSON_THROW_ON_ERROR);
+		} catch (Throwable $e) {
+			return [];
+		}
 	}
 }

--- a/lib/Db/ScriptInput.php
+++ b/lib/Db/ScriptInput.php
@@ -22,6 +22,8 @@ class ScriptInput extends Entity implements JsonSerializable {
 	protected ?int $scriptId = null;
 	protected ?string $options = null;
 
+	protected ?string $value = null;
+
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,
@@ -53,5 +55,13 @@ class ScriptInput extends Entity implements JsonSerializable {
 		} catch (Throwable $e) {
 			return [];
 		}
+	}
+
+	public function getValue(): ?string {
+		return $this->value;
+	}
+
+	public function setValue(?string $value): void {
+		$this->value = $value;
 	}
 }

--- a/lib/Interpreter/Context.php
+++ b/lib/Interpreter/Context.php
@@ -2,6 +2,7 @@
 
 namespace OCA\FilesScripts\Interpreter;
 
+use OCA\FilesScripts\Db\ScriptInput;
 use OCA\FilesScripts\Interpreter\Lua\LuaWrapper;
 use OCP\Files\Folder;
 use OCP\Files\Node;
@@ -10,6 +11,7 @@ use OCP\Files\NotFoundException;
 class Context {
 	/** @var Node[] */
 	private array $files;
+	/** @var ScriptInput[] */
 	private array $input;
 	private Folder $root;
 	private ?string $targetDirectory;

--- a/lib/Interpreter/Functions/Input/Get_Input.php
+++ b/lib/Interpreter/Functions/Input/Get_Input.php
@@ -2,15 +2,44 @@
 
 namespace OCA\FilesScripts\Interpreter\Functions\Input;
 
+use OCA\FilesScripts\Db\ScriptInput;
 use OCA\FilesScripts\Interpreter\RegistrableFunction;
 
 /**
- * `get_input(): Table`
+ * `get_input([String input_name=nil]): Table`
  *
- * Returns a Lua table containing the user inputs.
+ * Returns a Lua table containing the user inputs. If the optional `input_name` parameter is returned the value of the
+ * specified input is returned.
+ *
+ * ```lua
+ * get_input() 			-- { testVar= 'input' }
+ * get_input('testVar') -- 'input'
+ * ```
  */
 class Get_Input extends RegistrableFunction {
-	public function run(): array {
-		return $this->getContext()->getInput();
+	public function run($inputName = null) {
+		$inputs = [];
+		foreach ($this->getContext()->getInput() as $input) {
+			$inputs[$input->getName()] = $this->getRuntimeValue($input);
+		}
+
+		return $inputName === null
+			? $inputs
+			: $inputs[$inputName] ?? $inputName;
+	}
+
+	private function getRuntimeValue(ScriptInput $scriptInput) {
+		$scriptType = $scriptInput->getScriptOptions()['type'];
+		$value = $scriptInput->getValue();
+
+		switch ($scriptType) {
+			case 'filepick':
+				$node = $this->getNode($value);
+				return $node ? $this->getNodeData($node) : null;
+			case 'checkbox':
+				return (bool) $value;
+			default:
+				return $value;
+		}
 	}
 }

--- a/lib/Interpreter/Functions/Input/Get_Input.php
+++ b/lib/Interpreter/Functions/Input/Get_Input.php
@@ -25,11 +25,11 @@ class Get_Input extends RegistrableFunction {
 
 		return $inputName === null
 			? $inputs
-			: $inputs[$inputName] ?? $inputName;
+			: $inputs[$inputName] ?? null;
 	}
 
 	private function getRuntimeValue(ScriptInput $scriptInput) {
-		$scriptType = $scriptInput->getScriptOptions()['type'];
+		$scriptType = $scriptInput->getScriptOptions()['type'] ?? null;
 		$value = $scriptInput->getValue();
 
 		switch ($scriptType) {
@@ -39,7 +39,7 @@ class Get_Input extends RegistrableFunction {
 			case 'checkbox':
 				return (bool) $value;
 			default:
-				return $value;
+				return (string) $value;
 		}
 	}
 }

--- a/lib/Migration/Version020100Date20221126.php
+++ b/lib/Migration/Version020100Date20221126.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OCA\FilesScripts\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Extends the script input .
+ */
+class Version020100Date20221126 extends SimpleMigrationStep {
+	private LoggerInterface $logger;
+
+	public function __construct(LoggerInterface $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('filescript_inputs')) {
+			$table = $schema->getTable('filescript_inputs');
+			$table->addColumn('options', 'text', [
+				'notnull' => true,
+			]);
+		} else {
+			$this->logger->error('File scripts (Version020100Date20221126) migration failed, because `filescript_inputs` table does not exist.');
+		}
+		return $schema;
+	}
+}

--- a/src/api/script.ts
+++ b/src/api/script.ts
@@ -1,6 +1,6 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { Script, ScriptInput } from '../types/script'
+import { inflateScriptInputOptions, Script, ScriptInput } from '../types/script'
 
 export const api = {
 	async getScripts(): Promise<Script[]> {
@@ -24,10 +24,13 @@ export const api = {
 	},
 
 	async getScriptInputs(scriptId: Number): Promise<ScriptInput[]> {
-		return (await axios.get(generateUrl('/apps/files_scripts/scripts/' + scriptId + '/inputs'))).data
+		return (await axios.get(generateUrl('/apps/files_scripts/script_inputs/' + scriptId))).data
+			.map((scriptInput: ScriptInput) => {
+				return inflateScriptInputOptions(scriptInput)
+			})
 	},
 
-	async updateScriptInputs(script, scriptInputs) {
+	async updateScriptInputs(script: Script, scriptInputs: ScriptInput[]) {
 		return (await axios.post(generateUrl('/apps/files_scripts/script_inputs/' + script.id), { scriptInputs })).data
 	},
 }

--- a/src/components/ScriptEdit.vue
+++ b/src/components/ScriptEdit.vue
@@ -211,7 +211,7 @@ export default {
 .script-details {
 	flex: 0 0 25%;
 	height: 90vh;
-	margin-right: 12px;
+	padding-right: 12px;
 	overflow-y: auto;
 	overflow-x: clip;
 }

--- a/src/components/ScriptEdit/EditInputDetails.vue
+++ b/src/components/ScriptEdit/EditInputDetails.vue
@@ -1,0 +1,135 @@
+<template>
+	<div>
+		<div style="text-align: right;">
+			<NcButton type="tertiary" @click="back" style="display: inline;">
+				<template #icon>
+					<KeyboardBackspace :size="16" />
+				</template>
+				{{ t('files_scripts', 'Back') }}
+			</NcButton>
+		</div>
+
+		<div class="inputs">
+			<NcTextField :value.sync="scriptInput.name"
+				:label="t('files_scripts', 'Variable name')"
+				:label-visible="true"
+			/>
+			<NcTextField :value.sync="scriptInput.description" :label="t('files_scripts', 'User prompt')"  :label-visible="true" />
+
+			<div>
+				<div class="input_label">{{ t('files_scripts', 'Input type') }}</div>
+				<NcMultiselect
+					class="full_width"
+					@change="changeInputType"
+					v-model="inputType"
+					:options="Object.values(InputTypes)"
+					trackBy="id"
+					label="label"
+				/>
+			</div>
+
+			<MultiInput
+				v-if="isInputMultiselect"
+				:label="t('files_scripts', 'Multi-select options')"
+				v-model="this.scriptInput.options.multiselectOptions"
+			/>
+			<MultiInput
+				v-if="isInputFilepick"
+				:label="t('files_scripts', 'Allowed mime-types (defaults to all)')"
+				v-model="this.scriptInput.options.filepickMimes"
+			/>
+		</div>
+
+		<NcButton type="primary" @click="save">
+			<template #icon><ContentSave :size="20" /></template>
+			{{ t('files_scripts', 'Save') }}
+		</NcButton>
+	</div>
+</template>
+
+<script lang="ts">
+import { NcTextField, NcButton, NcMultiselect } from '@nextcloud/vue'
+import ContentSave from 'vue-material-design-icons/ContentSave.vue'
+import KeyboardBackspace from 'vue-material-design-icons/KeyboardBackspace.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import { ScriptInput } from '../../types/script'
+import { translate as t } from '../../l10n'
+import MultiInput from '../generic/MultiInput.vue'
+
+const InputTypes = {
+	text: { id: "text", label: t('files_scripts', 'Text')},
+  checkbox: { id: "checkbox", label: t('files_scripts', 'Checkbox') },
+	filepick: { id: "filepick", label: t('files_scripts', 'File picker') },
+	multiselect: { id: "multiselect", label: t('files_scripts', 'Multi-select') },
+}
+
+export default {
+	name: 'EditInputDetails',
+	components: {
+		NcTextField,
+		NcButton,
+		ContentSave,
+		KeyboardBackspace,
+		Plus,
+		NcMultiselect,
+		MultiInput
+	},
+	props: {
+		scriptInput: Object as () => ScriptInput,
+	},
+	mounted() {
+		this.scriptInput.value = null
+	},
+	data() {
+		return {
+			InputTypes,
+			inputType: InputTypes[this.scriptInput.options.type] ?? InputTypes.text,
+		}
+	},
+	computed: {
+		isInputMultiselect() {
+			return this.inputType?.id === 'multiselect'
+		},
+		isInputFilepick() {
+			return this.inputType?.id === 'filepick'
+		}
+	},
+	methods: {
+		t,
+		save() {
+			this.$emit('save', this.scriptInput)
+		},
+		back() {
+			this.$emit('cancel')
+		},
+		changeInputType(inputType) {
+			this.scriptInput.options = {
+				type: inputType.id,
+				filepickMimes: [],
+				multiselectOptions: []
+			}
+		}
+	},
+}
+</script>
+
+<style scoped>
+.inputs {
+	font-weight: bold;
+	margin-bottom: 18px;
+}
+.input_label {
+	padding: 4px 0;
+}
+.full_width {
+	width: 100%;
+}
+.inputs ol {
+	font-weight: normal;
+	list-style-type: decimal;
+	list-style-position: inside;
+}
+.inputs ol:before {
+	font-weight:bold;
+}
+</style>

--- a/src/components/ScriptEdit/EditInputs.vue
+++ b/src/components/ScriptEdit/EditInputs.vue
@@ -73,11 +73,6 @@ export default {
 			editingInput: null
 		}
 	},
-	watch: {
-		scriptId(newVal) {
-			(newVal !== null) && this.fetchInputs()
-		},
-	},
 	mounted() {
 		this.fetchInputs()
 	},
@@ -117,7 +112,7 @@ export default {
 			this.updated()
 		},
 		updated() {
-			this.$emit('changed', Object.values(this.scriptInputs))
+			this.$emit('changed', this.scriptInputs)
 		},
 		async fetchInputs() {
 			if (this.scriptId === null) {
@@ -132,6 +127,7 @@ export default {
 			})
 			this.scriptInputs = scriptInputs
 			this.loading = false
+			this.updated()
 		},
 	},
 }

--- a/src/components/ScriptEdit/EditInputs.vue
+++ b/src/components/ScriptEdit/EditInputs.vue
@@ -6,61 +6,57 @@
 		</div>
 
 		<div v-if="loading" class="icon-loading" />
-		<div v-else class="script-input">
-			<input v-model="inputName"
-				type="text"
-				class="input-name"
-				:placeholder="t('files_scripts', 'Variable name')">
-			<input v-model="inputDescription"
-				type="text"
-				class="input-description"
-				:placeholder="t('files_scripts', 'User prompt …')">
-			<div class="input-action">
-				<NcActions>
-					<NcActionButton @click="addInput()">
-						<template #icon>
-							<Plus :size="20" />
-						</template>
-					</NcActionButton>
-				</NcActions>
-			</div>
+		<div v-else-if="this.editingInput">
+			<EditInputDetails :scriptInput="this.editingInput" @save="saveInput" @cancel="resetEditing"/>
 		</div>
-		<div v-for="(scriptInput, idx) in scriptInputs"
-			:key="idx"
-			class="script-input">
-			<div class="input-name">
-				{{ scriptInput.name }}
+		<div v-else>
+			<div v-for="(scriptInput, idx) in scriptInputs"
+					 :key="idx"
+					 class="script-input">
+				<div class="input-name">{{ scriptInput.name }}</div>
+				<div class="input-description">{{ scriptInput.description }}</div>
+				<div class="input-action">
+					<NcActions>
+						<NcActionButton icon="icon-rename" :close-after-click="true" @click="edit(scriptInput)">
+							{{ t('files_scripts', 'Edit') }}
+						</NcActionButton>
+						<NcActionButton @click="remove(scriptInput)">
+							{{ t('files_scripts', 'Delete') }}
+							<template #icon>
+								<Delete :size="20" @click="remove(scriptInput)" />
+							</template>
+						</NcActionButton>
+					</NcActions>
+				</div>
 			</div>
-			<div class="input-description">
-				{{ scriptInput.description }}
-			</div>
-			<div class="input-action">
-				<NcActions>
-					<NcActionButton @click="remove(scriptInput.name)">
-						<template #icon>
-							<Delete :size="20" @click="remove(scriptInput)" />
-						</template>
-					</NcActionButton>
-				</NcActions>
+			<div>
+				<NcButton type="secondary" @click="addInput">
+					<template #icon><Plus :size="16" /></template>
+					{{ t('files_scripts', 'Add input') }}
+				</NcButton>
 			</div>
 		</div>
 	</div>
 </template>
 
 <script lang="ts">
-import { NcActions, NcActionButton } from '@nextcloud/vue'
+import { NcActions, NcActionButton, NcButton } from '@nextcloud/vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
-import { ScriptInput } from '../../types/script'
+import {createScriptInput, ScriptInput} from '../../types/script'
 import Vue from 'vue'
 import { api } from '../../api/script'
 import { translate as t } from '../../l10n'
+import EditInputDetails from './EditInputDetails.vue'
+import {showInfo} from "@nextcloud/dialogs";
 
 export default {
 	name: 'EditInputs',
 	components: {
+		EditInputDetails,
 		NcActions,
 		NcActionButton,
+		NcButton,
 		Plus,
 		Delete,
 	},
@@ -73,6 +69,8 @@ export default {
 			inputDescription: '',
 			scriptInputs: {},
 			loading: true,
+			editingInputName: null,
+			editingInput: null
 		}
 	},
 	watch: {
@@ -86,19 +84,33 @@ export default {
 	methods: {
 		t,
 		addInput() {
-			if (this.inputName.trim().length === 0) {
-				return
+			this.edit(createScriptInput('', ''))
+		},
+		saveInput(scriptInput: ScriptInput) {
+			if (scriptInput.name === '') {
+				showInfo(t('files_scripts', 'Script input name cannot be empty'))
+				return;
 			}
 
-			this.scriptInputs[this.inputName] = {
-				name: this.inputName,
-				description: this.inputDescription,
-			} as ScriptInput
+			if (scriptInput.name !== this.editingInputName && (scriptInput.name in this.scriptInputs)) {
+				showInfo(t('files_scripts', 'Script input name already in use.'))
+				return;
+			}
 
-			this.inputName = ''
-			this.inputDescription = ''
-
+			if (scriptInput.name !== this.editingInputName) {
+				Vue.delete(this.scriptInputs, this.editingInputName)
+			}
+			this.scriptInputs[scriptInput.name] = scriptInput
+			this.resetEditing();
 			this.updated()
+		},
+		resetEditing() {
+			this.editingInput = null
+			this.editingInputName = null
+		},
+		edit(scriptInput: ScriptInput) {
+			this.editingInput = Object.assign({}, scriptInput)
+			this.editingInputName = scriptInput.name
 		},
 		remove(scriptInput: ScriptInput) {
 			Vue.delete(this.scriptInputs, scriptInput.name)

--- a/src/components/ScriptSelect/ScriptInputComponent.vue
+++ b/src/components/ScriptSelect/ScriptInputComponent.vue
@@ -1,0 +1,155 @@
+<template>
+	<div class="section-wrapper">
+
+		<!-- Checkbox -->
+		<template v-if="isInputCheckbox">
+			<CheckboxMultipleMarkedCircle class="section-label" :size="20" />
+			<NcCheckboxRadioSwitch
+				class="section-details checkbox"
+				type="switch"
+				:checked.sync="scriptInput.value"
+			>
+				{{ this.scriptInput.description }}
+			</NcCheckboxRadioSwitch>
+		</template>
+
+		<!-- Multiselect -->
+		<template v-else-if="isInputMultiselect">
+			<FormSelect class="section-label" :size="20" />
+			<NcMultiselect v-model="scriptInput.value"
+				class="section-details"
+				:options="scriptInput.options.multiselectOptions"
+				:placeholder="this.scriptInput.description"
+			/>
+		</template>
+
+		<!-- Filepick -->
+		<template v-else-if="isInputFilepick">
+			<Folder class="section-label" :size="20" />
+			<input v-model="scriptInput.value"
+			 class="section-details"
+			 type="text"
+			 style="cursor: pointer;"
+			 :placeholder="scriptInput.description"
+			 @click="filepick"
+			/>
+		</template>
+
+
+		<!-- Default: text -->
+		<template v-else>
+			<FormTextbox class="section-label" :size="20" />
+			<input
+				v-model="scriptInput.value"
+				type="text"
+				class="section-details"
+				:placeholder="scriptInput.description"
+			/>
+		</template>
+	</div>
+</template>
+
+<script lang="ts">
+import { ScriptInput } from '../../types/script'
+import FormTextbox from 'vue-material-design-icons/FormTextbox.vue';
+import FormSelect from 'vue-material-design-icons/FormSelect.vue';
+import CheckboxMultipleMarkedCircle from 'vue-material-design-icons/CheckboxMultipleMarkedCircle.vue';
+import Folder from 'vue-material-design-icons/Folder.vue';
+import { NcCheckboxRadioSwitch, NcMultiselect } from '@nextcloud/vue'
+import { FilePickerBuilder, showError } from "@nextcloud/dialogs";
+import { translate as t } from '../../l10n';
+import * as path from 'path';
+
+export default {
+	name: 'ScriptInputComponent',
+	props: {
+		scriptInput: Object as () => ScriptInput
+	},
+	components: {
+		FormTextbox,
+		FormSelect,
+		CheckboxMultipleMarkedCircle,
+		Folder,
+		NcCheckboxRadioSwitch,
+		NcMultiselect,
+	},
+	mounted() {
+		this.resetValue()
+	},
+	computed: {
+		type() {
+			return this.scriptInput.options.type
+		},
+		isInputCheckbox() {
+			return this.type === 'checkbox'
+		},
+		isInputMultiselect() {
+			return this.type === 'multiselect'
+		},
+		isInputFilepick() {
+			return this.type === 'filepick'
+		},
+	},
+	methods: {
+		t,
+		resetValue() {
+			this.scriptInput.value = this.getDefaultValue()
+		},
+		getDefaultValue() {
+			switch (this.type) {
+				case 'checkbox': return false
+				default: return ''
+			}
+		},
+		async filepick() {
+			const mimetypes = this.scriptInput.options.filepickMimes;
+			const allowDirectories = mimetypes.includes('httpd/unix-directory')
+			const pickerBuiler = (new FilePickerBuilder(this.scriptInput.description))
+					.allowDirectories(allowDirectories)
+					.startAt('/')
+
+			if (mimetypes.length > 0) {
+				pickerBuiler.setMimeTypeFilter(mimetypes)
+			}
+
+			const picker = pickerBuiler.build()
+			try {
+				const dir = await picker.pick() || '/'
+				this.scriptInput.value = path.normalize(dir)
+			} catch (error) {
+				showError(error.message || t('files_scripts', 'Unknown error'))
+			}
+		},
+	}
+}
+</script>
+
+<style scoped lang="scss">
+.checkbox {
+	margin-left: 8px;
+}
+.section-wrapper {
+		display: flex;
+		max-width: 100%;
+		margin-top: 10px;
+
+	.section-label {
+		background-position: 0 center;
+		width: 28px;
+		flex-shrink: 0;
+		text-align: center;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		z-index: 100000;
+	}
+
+	.section-details {
+		flex-grow: 1;
+
+		button.action-item--single {
+			margin-top: -6px;
+		}
+	}
+}
+</style>

--- a/src/components/generic/MultiInput.vue
+++ b/src/components/generic/MultiInput.vue
@@ -1,0 +1,65 @@
+<template>
+	<div>
+		<NcTextField
+			:label="label"
+			:label-visible="true"
+			:value.sync="input"
+			:showTrailingButton="true"
+			trailingButtonIcon="arrowRight"
+			@trailing-button-click="insertValue"
+			v-on:keyup.enter="insertValue"
+		/>
+		<ol>
+			<li v-for="(option, idx) in this.values" :key="idx">
+				{{ option }}
+			</li>
+		</ol>
+	</div>
+</template>
+
+<script lang="ts">
+import { NcTextField } from '@nextcloud/vue'
+
+export default {
+	name: 'MultiInput',
+	model: {
+		prop: 'values',
+		event: 'change'
+	},
+	components: {
+		NcTextField
+	},
+	props: {
+		label: String,
+		values: {
+			type: Array,
+			default: () => []
+		}
+	},
+	data() {
+		return {
+			input: ''
+		}
+	},
+	methods: {
+		insertValue() {
+			if (this.input === '' || this.values.includes(this.input)) {
+				return;
+			}
+			this.values.push(this.input)
+			this.input = ''
+		}
+	},
+}
+</script>
+
+<style scoped>
+ol {
+	font-weight: normal;
+	list-style-type: decimal;
+	list-style-position: inside;
+}
+ol:before {
+	font-weight:bold;
+}
+</style>

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -13,7 +13,14 @@ export interface ScriptInput {
 	scriptId: number
 	name: string
 	description: string
+	options: ScriptInputOptions
 	value: string
+}
+
+export interface ScriptInputOptions {
+	type: string,
+	multiselectOptions: string[]
+	filepickMimes: string[]
 }
 
 /**
@@ -28,5 +35,28 @@ export function defaultScript(): Script {
 		program: '',
 		background: false,
 		requestDirectory: false,
+	}
+}
+
+export function createScriptInput(name: string, description: string): ScriptInput {
+	return {
+		name,
+		description,
+		options: {
+			type: 'text',
+			multiselectOptions: [],
+			filepickMimes: [],
+		} as ScriptInputOptions
+	} as ScriptInput
+}
+
+export function inflateScriptInputOptions(scriptInput: ScriptInput): ScriptInput {
+	return {
+		...scriptInput,
+		options: {
+			type: scriptInput.options.type ?? 'text',
+			multiselectOptions: scriptInput.options.multiselectOptions ?? [],
+			filepickMimes: scriptInput.options.filepickMimes ?? []
+		}
 	}
 }

--- a/src/views/ScriptSelect.vue
+++ b/src/views/ScriptSelect.vue
@@ -25,13 +25,7 @@
 						@click="pickOutputDirectory">
 				</div>
 
-				<div v-for="scriptInput in scriptInputs" :key="scriptInput.id" class="section-wrapper">
-					<ConsoleLine class="section-label" :size="20" />
-					<input v-model="scriptInput.value"
-						type="text"
-						class="section-details"
-						:placeholder="scriptInput.description">
-				</div>
+				<ScriptInputComponent v-for="scriptInput in scriptInputs" :key="scriptInput.id" :scriptInput="scriptInput" />
 
 				<div class="script-info">
 					{{ selectedDescription }}
@@ -67,6 +61,7 @@ import * as path from 'path'
 import { translate as t } from '../l10n'
 import { registerFileSelect, registerMultiSelect } from '../files'
 import { ScriptInput } from '../types/script'
+import ScriptInputComponent from '../components/ScriptSelect/ScriptInputComponent.vue'
 
 export default {
 	name: 'ScriptSelect',
@@ -78,6 +73,7 @@ export default {
 		ConsoleLine,
 		Folder,
 		Play,
+		ScriptInputComponent
 	},
 	data() {
 		return {

--- a/tests/unit/Lua/InputTest.php
+++ b/tests/unit/Lua/InputTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace OCA\FilesScripts\Lua;
+
+use OCA\FilesScripts\Db\ScriptInput;
+
+class InputTest extends LuaTestCase {
+
+	public function testInputTypes() {
+		$inputs = [
+			ScriptInput::fromParams([
+				'name' => 'text',
+				'options' => json_encode(['type'=> 'text']),
+				'value' => 'true'
+			]),
+
+			ScriptInput::fromParams([
+				'name' => 'multiselect',
+				'options' => json_encode(['type'=> 'text']),
+				'value' => 'true'
+			]),
+
+			ScriptInput::fromParams([
+				'name' => 'no_options',
+				'value' => 1
+			]),
+
+			ScriptInput::fromParams([
+				'name' => 'checkbox1',
+				'options' => json_encode(['type'=> 'checkbox']),
+				'value' => '1'
+			]),
+
+			ScriptInput::fromParams([
+				'name' => 'checkbox2',
+				'options' => json_encode(['type'=> 'checkbox']),
+				'value' => '0'
+			]),
+
+			ScriptInput::fromParams([
+				'name' => 'filepick',
+				'options' => json_encode(['type'=> 'filepick']),
+				'value' => '/test/'
+			]),
+		];
+
+		$program = <<<LUA
+checkbox1 = get_input('checkbox1')
+checkbox2 = get_input('checkbox2')
+text = get_input('text')
+multiselect = get_input('multiselect')
+no_options = get_input('no_options')
+filepick = get_input('filepick')
+
+unknown = get_input('unknown')
+
+all_inputs = get_input()
+LUA;
+
+
+		$lua = $this->runLua($program, $inputs);
+
+		// Check types are expected
+		$this->assertIsBool($lua->getGlobalVariable('checkbox1'));
+		$this->assertIsBool($lua->getGlobalVariable('checkbox2'));
+		$this->assertIsString($lua->getGlobalVariable('text'));
+		$this->assertIsString($lua->getGlobalVariable('multiselect'));
+		$this->assertIsString($lua->getGlobalVariable('no_options'));
+
+		// Check filepick gets converted to a node type
+		$filepick = $lua->getGlobalVariable('filepick');
+		$this->assertIsArray($filepick);
+		$this->assertEquals('file', $filepick['_type']);
+
+		// Unknown inputs should return null
+		$this->assertNull($lua->getGlobalVariable('unknown'));
+
+
+		// Check that get_inputs() returns array of all inputs
+		$allInputs = $lua->getGlobalVariable('all_inputs');
+		$this->assertIsArray($allInputs);
+		foreach ($inputs as $input) {
+			$this->assertArrayHasKey($input->getName(), $allInputs);
+		}
+	}
+}

--- a/tests/unit/Lua/LuaTestCase.php
+++ b/tests/unit/Lua/LuaTestCase.php
@@ -8,26 +8,26 @@ use OCA\FilesScripts\Interpreter\Interpreter;
 use OCA\FilesScripts\Interpreter\Lua\LuarInterpreter;
 use OCA\FilesScripts\TestFunctionProvider;
 use OCA\FilesScripts\TestTempManager;
-use OCP\Files\SimpleFS\ISimpleFolder;
 use PHPUnit\Framework\TestCase;
 
 abstract class LuaTestCase extends TestCase {
-	protected function runLua(string $program) {
-		$folder = $this->collectiveFolder = $this->getMockBuilder(Folder::class)
-			->disableOriginalConstructor()
-			->getMock();
+	protected function runLua(string $program, array $inputs = []) {
+		$mockFolder = $this->getMockBuilder(Folder::class)
+			->disableOriginalConstructor()->getMock();
+		$mockFolder->method('get')->willReturn($mockFolder);
+		$mockFolder->method('getId')->willReturn('rootFolder');
 
 		$lua = new LuarInterpreter();
 		$context = new Context(
 			$lua,
-			$folder,
-			[],
+			$mockFolder,
+			$inputs,
 			[],
 			null
 		);
 
 		$interpreter = new Interpreter(
-			new TestFunctionProvider(),
+			new TestFunctionProvider($this),
 			new TestTempManager()
 		);
 

--- a/tests/unit/TestFunctionProvider.php
+++ b/tests/unit/TestFunctionProvider.php
@@ -118,8 +118,7 @@ class TestFunctionProvider implements IFunctionProvider {
 		];
 	}
 
-	public function isRegistrable(): bool
-	{
-		// TODO: Implement isRegistrable() method.
+	public function isRegistrable(): bool {
+		return true;
 	}
 }


### PR DESCRIPTION
Resolves: https://github.com/Raudius/files_scripts/issues/13


Allows administrators to determine the type of the user input (text, checkbox, multiselect, file-pick). Allowing for more restrictive user inputs.

**Administration**
![image](https://user-images.githubusercontent.com/3178979/204338423-63eec3af-ccf4-4020-8641-88fb9f967a7f.png)

**Action select**
![image](https://user-images.githubusercontent.com/3178979/204338152-942f1ae3-aec1-45ea-9b0a-2c1b4a8f819b.png)
