### PR TITLE
Actions can be directly in menu

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -20,6 +20,7 @@ class Application extends App implements IBootstrap {
 
 	public const APP_CONFIG_FIRST_RUN = 'first_run';
 	public const APP_CONFIG_USE_PHP_INTERPRETER = 'php_interpreter';
+	public const APP_CONFIG_ACTIONS_IN_MENU = 'actions_in_menu';
 
 	public function __construct() {
 		parent::__construct(self::APP_ID);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -35,6 +35,9 @@ class SettingsController extends Controller {
 			case Application::APP_CONFIG_USE_PHP_INTERPRETER:
 				$this->config->setAppValue(Application::APP_ID, Application::APP_CONFIG_USE_PHP_INTERPRETER, $value);
 				return $success;
+			case Application::APP_CONFIG_ACTIONS_IN_MENU:
+				$this->config->setAppValue(Application::APP_ID, Application::APP_CONFIG_ACTIONS_IN_MENU, $value);
+				return $success;
 			default:
 				return new JSONResponse(['error' => 'Unknown option with name: ' . $name], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Listener/LoadAdditionalListener.php
+++ b/lib/Listener/LoadAdditionalListener.php
@@ -4,17 +4,34 @@ declare(strict_types=1);
 
 namespace OCA\FilesScripts\Listener;
 
+use OCP\AppFramework\Services\IInitialState;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\FilesScripts\AppInfo\Application;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
+use OCP\IConfig;
 
 class LoadAdditionalListener implements IEventListener {
+
+	private IConfig $config;
+	private IInitialState $initialStateService;
+
+	public function __construct(
+		IConfig $config,
+		IInitialState $initialStateService
+	) {
+		$this->config = $config;
+		$this->initialStateService = $initialStateService;
+	}
+
 	public function handle(Event $event): void {
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {
 			return;
 		}
+
+		$actionsInMenu = $this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_ACTIONS_IN_MENU, 'false') === 'true';
+		$this->initialStateService->provideInitialState('actions_in_menu', $actionsInMenu);
 
 		Util::addStyle(Application::APP_ID, 'global');
 		Util::addScript(Application::APP_ID, 'files_scripts-main');

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -24,7 +24,9 @@ class AdminSettings implements ISettings {
 
 	public function getForm(): TemplateResponse {
 		$usePhpInterpreter = $this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_USE_PHP_INTERPRETER, 'false') === 'true';
+		$actionsInMenu = $this->config->getAppValue(Application::APP_ID, Application::APP_CONFIG_ACTIONS_IN_MENU, 'false') === 'true';
 		$this->initialStateService->provideInitialState('use_php_interpreter', $usePhpInterpreter);
+		$this->initialStateService->provideInitialState('actions_in_menu', $actionsInMenu);
 		$this->initialStateService->provideInitialState('lua_plugin_available', LuaProvider::isLuaPluginAvailable());
 
 		Util::addScript(Application::APP_ID, 'files_scripts-main');

--- a/src/files.ts
+++ b/src/files.ts
@@ -40,3 +40,22 @@ export function registerFileSelect(actionHandler) {
 		actionHandler,
 	})
 }
+
+/**
+ * Registers the action handler on the file context menu.
+ *
+ * @param {Int} menuId unique id to identify menu item
+ * @param {String} menuTitle Text of menu item
+ * @param {String} menuIcon  icon class (default 'icon-files_scripts')
+ * @param {Function} actionHandler Callback to the handler
+ */
+export function registerFileSelectDirect(menuId, menuTitle, menuIcon, actionHandler ) {
+	OCA.Files.fileActions.registerAction({
+		name: 'files_scripts_action' + menuId,
+		displayName: menuTitle,
+		mime: 'all',
+		permissions: OC.PERMISSION_READ,
+		iconClass: menuIcon || 'icon-files_scripts',
+		actionHandler,
+	})
+}

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -40,6 +40,15 @@
 				</template>
 			</NcEmptyContent>
 		</NcSettingsSection>
+		<!-- Direct menu items -->
+		<NcSettingsSection
+			:limitWidth="false"
+			:title="t('files_scripts', 'Actions in menu')"
+			:description="t('files_scripts', 'Show file actions directly in menu instead via one menu item &amp;More actions&amp;.')" >
+			<NcCheckboxRadioSwitch type="switch" :checked="this.actionsInMenu" @update:checked="toggleActionsInMenu">
+				{{ t('files_scripts', 'Actions in menu') }}
+			</NcCheckboxRadioSwitch>
+		</NcSettingsSection>
 
 		<!-- PHP interpreter section -->
 		<NcSettingsSection
@@ -95,6 +104,7 @@ export default {
 	data() {
 		return {
 			usePhpInterpreter: loadState('files_scripts', 'use_php_interpreter', false),
+			actionsInMenu: loadState('files_scripts', 'actions_in_menu', false),
 			pluginAvailable: loadState('files_scripts', 'lua_plugin_available', false)
 		}
 	},
@@ -124,6 +134,18 @@ export default {
 			} catch (error) {
 				showError(error.response.data.error)
 				this.usePhpInterpreter = !value
+			}
+		},
+		async toggleActionsInMenu(value) {
+			this.actionsInMenu = value
+			try {
+				await axios.post(generateUrl('/apps/files_scripts/settings'), {
+					name: 'actions_in_menu',
+					value: value ? 'true' : 'false'
+				})
+			} catch (error) {
+				showError(error.response.data.error)
+				this.actionsInMenu = !value
 			}
 		}
 	},


### PR DESCRIPTION
This provide configuration option `Action in menu`, which causes that enabled script actions are directly in menu, not hiden under `More actions` item.