### PR TITLE
Adds custom messages

### DIFF
--- a/lib/Controller/ScriptController.php
+++ b/lib/Controller/ScriptController.php
@@ -183,10 +183,13 @@ class ScriptController extends Controller {
 		try {
 			$this->scriptService->runScript($script, $context);
 		} catch (AbortException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], HTTP::STATUS_BAD_REQUEST);
+			return new JSONResponse([
+				'error' => $e->getMessage(),
+				'messages' => $context->getMessages()
+			], HTTP::STATUS_BAD_REQUEST);
 		}
 
-		return new JSONResponse();
+		return new JSONResponse(['messages' => $context->getMessages()]);
 	}
 
 	/**

--- a/lib/Interpreter/Context.php
+++ b/lib/Interpreter/Context.php
@@ -17,6 +17,8 @@ class Context {
 	private ?string $targetDirectory;
 	private LuaWrapper $lua;
 
+	private array $messages = [];
+
 	public function __construct(
 		LuaWrapper $lua,
 		Folder $root,
@@ -29,6 +31,19 @@ class Context {
 		$this->input = $input;
 		$this->files = $files;
 		$this->targetDirectory = $targetDirectory;
+
+		$this->messages = [];
+	}
+
+	public function clearMessages(): void {
+		$this->messages = [];
+	}
+
+	public function addMessage($message, $type=null): void {
+		$this->messages[] = [
+			'message' => $message,
+			'type' => $type
+		];
 	}
 
 	public function getTargetDirectory(): ?Folder {
@@ -64,5 +79,9 @@ class Context {
 	 */
 	public function getInputFiles(): array {
 		return $this->files;
+	}
+
+	public function getMessages(): array {
+		return $this->messages;
 	}
 }

--- a/lib/Interpreter/FunctionProvider.php
+++ b/lib/Interpreter/FunctionProvider.php
@@ -3,6 +3,8 @@
 namespace OCA\FilesScripts\Interpreter;
 
 use OCA\FilesScripts\Interpreter\Functions\Error\Abort;
+use OCA\FilesScripts\Interpreter\Functions\Error\Add_Message;
+use OCA\FilesScripts\Interpreter\Functions\Error\Clear_Messages;
 use OCA\FilesScripts\Interpreter\Functions\Error\Log;
 use OCA\FilesScripts\Interpreter\Functions\Files\Copy_File;
 use OCA\FilesScripts\Interpreter\Functions\Files\Directory_Listing;
@@ -117,7 +119,9 @@ class FunctionProvider implements IFunctionProvider {
 		Comment_Delete $f52,
 		Comment_Create $f53,
 		Get_File_Tags $f54,
-		New_Folder $f55
+		New_Folder $f55,
+		Add_Message $f56,
+		Clear_Messages $f57
 	) {
 		$this->functions = func_get_args();
 	}

--- a/lib/Interpreter/Functions/Error/Abort.php
+++ b/lib/Interpreter/Functions/Error/Abort.php
@@ -11,7 +11,7 @@ use OCA\FilesScripts\Interpreter\RegistrableFunction;
  * Aborts execution with an error message. This error message will be shown to the user in a toast dialog.
  */
 class Abort extends RegistrableFunction {
-	public function run($error = null): array {
+	public function run($error = null): void {
 		$error = (string) $error;
 		throw new AbortException($error);
 	}

--- a/lib/Interpreter/Functions/Error/Add_Message.php
+++ b/lib/Interpreter/Functions/Error/Add_Message.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Error;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+
+/**
+ * `add_message(String message, [String type="info"]): void`
+ *
+ * Adds a message to be shown to the user after the action is completed as a toast message. The optional type parameter
+ * determines the type of toast shown.
+ *
+ * Type can be one of: "error", "warning", "success" or "info" (default).
+ *
+ * ```lua
+ * add_message("I'm Blue")
+ * add_message("I'm Red", "error")
+ * add_message("I'm Orange", "warning")
+ * add_message("I'm Green", "success")
+ * ```
+ */
+class Add_Message extends RegistrableFunction {
+	public function run($message = null, $type = null): void {
+		if (!is_string($message)) {
+			return;
+		}
+		$type = is_string($type) ? $type : "info";
+
+		$this->getContext()->addMessage($message, $type);
+	}
+}

--- a/lib/Interpreter/Functions/Error/Clear_Messages.php
+++ b/lib/Interpreter/Functions/Error/Clear_Messages.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Error;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+
+/**
+ * `clear_messages(String message, [String type="info"]): void`
+ *
+ * Clears all messages that have been previously added with [`add_message`](#add_message).
+ *
+ * ```lua
+ * add_message("Don't show this...")
+ * add_message("...or this")
+ *
+ * clear_messages()
+ *
+ * add_message("Show this")
+ * add_message("...and this")
+ * ```
+ */
+class Clear_Messages extends RegistrableFunction {
+	public function run(): void {
+		$this->getContext()->clearMessages();
+	}
+}

--- a/src/types/Messages.ts
+++ b/src/types/Messages.ts
@@ -17,20 +17,25 @@ export function getMessageType(type: any): MessageType {
 }
 
 export function showMessage(message: Message) {
+	const options = {
+		timeout: 10000
+	}
+
+
 	switch (message.type) {
 		case MessageType.ERROR:
-			showError(message.message)
+			showError(message.message, options)
 			return
 
 		case MessageType.WARNING:
-			showWarning(message.message)
+			showWarning(message.message, options)
 			return;
 
 		case MessageType.SUCCESS:
-			showSuccess(message.message)
+			showSuccess(message.message, options)
 			return;
 
 		default:
-			showInfo(message.message)
+			showInfo(message.message, options)
 	}
 }

--- a/src/types/Messages.ts
+++ b/src/types/Messages.ts
@@ -1,0 +1,36 @@
+import {showError, showSuccess, showWarning, showInfo} from '@nextcloud/dialogs'
+
+export enum MessageType {
+	ERROR = 'error',
+	WARNING = 'warning',
+	INFO = 'info',
+	SUCCESS = 'success'
+}
+
+export interface Message {
+	message: string
+	type: MessageType
+}
+
+export function getMessageType(type: any): MessageType {
+	return MessageType[type] ?? MessageType.INFO
+}
+
+export function showMessage(message: Message) {
+	switch (message.type) {
+		case MessageType.ERROR:
+			showError(message.message)
+			return
+
+		case MessageType.WARNING:
+			showWarning(message.message)
+			return;
+
+		case MessageType.SUCCESS:
+			showSuccess(message.message)
+			return;
+
+		default:
+			showInfo(message.message)
+	}
+}

--- a/src/types/Messages.ts
+++ b/src/types/Messages.ts
@@ -21,7 +21,6 @@ export function showMessage(message: Message) {
 		timeout: 10000
 	}
 
-
 	switch (message.type) {
 		case MessageType.ERROR:
 			showError(message.message, options)

--- a/src/views/ScriptSelect.vue
+++ b/src/views/ScriptSelect.vue
@@ -63,7 +63,7 @@ import * as path from 'path'
 import {translate as t} from '../l10n'
 import {registerFileSelect, registerFileSelectDirect, registerMultiSelect, registerMultiSelectDirect} from '../files'
 import ScriptInputComponent from '../components/ScriptSelect/ScriptInputComponent.vue'
-import {getMessageType, Message, MessageType, showMessage} from "../types/Messages";
+import {MessageType, showMessage} from "../types/Messages";
 import {FilePickerBuilder, showError} from "@nextcloud/dialogs";
 
 export default {
@@ -148,12 +148,6 @@ export default {
 				const currentDir = OCA.Files.App.getCurrentFileList().getCurrentDirectory()
 				OCA.Files.App.fileList.changeDirectory(currentDir, true, true)
 
-				for (let message of response.messages) {
-					messages.push({
-						message: message.text,
-						type: getMessageType(message.type)
-					} as Message)
-				}
 				messages = response.messages ?? []
 				messages.push({ message: (t('files_scripts', 'Action completed!')), type: MessageType.SUCCESS })
 				this.closeModal()

--- a/src/views/ScriptSelect.vue
+++ b/src/views/ScriptSelect.vue
@@ -52,20 +52,19 @@
 </template>
 
 <script lang="ts">
-import { loadState } from '@nextcloud/initial-state'
-import '@nextcloud/dialogs/styles/toast.scss'
-import { NcMultiselect, NcModal, NcButton } from "@nextcloud/vue";
+import {loadState} from '@nextcloud/initial-state'
+import {NcButton, NcModal, NcMultiselect} from "@nextcloud/vue";
 import FileCog from 'vue-material-design-icons/FileCog.vue'
 import ConsoleLine from 'vue-material-design-icons/ConsoleLine.vue'
 import Play from 'vue-material-design-icons/Play.vue'
 import Folder from 'vue-material-design-icons/Folder.vue'
-import { showError, FilePickerBuilder, showSuccess } from '@nextcloud/dialogs'
-import { api } from '../api/script'
+import {api} from '../api/script'
 import * as path from 'path'
-import { translate as t } from '../l10n'
-import {registerFileSelect, registerMultiSelect, registerFileSelectDirect, registerMultiSelectDirect} from '../files'
-import { ScriptInput } from '../types/script'
+import {translate as t} from '../l10n'
+import {registerFileSelect, registerFileSelectDirect, registerMultiSelect, registerMultiSelectDirect} from '../files'
 import ScriptInputComponent from '../components/ScriptSelect/ScriptInputComponent.vue'
+import {getMessageType, Message, MessageType, showMessage} from "../types/Messages";
+import {FilePickerBuilder, showError} from "@nextcloud/dialogs";
 
 export default {
 	name: 'ScriptSelect',
@@ -139,21 +138,37 @@ export default {
 			if (this.isRunning) {
 				return
 			}
+
 			this.isRunning = true
+			let messages = []
+
 			try {
-				await api.runScript(this.selectedScript, this.outputDirectory, this.scriptInputs, this.selectedFiles)
+				let response = await api.runScript(this.selectedScript, this.outputDirectory, this.scriptInputs, this.selectedFiles)
 
 				const currentDir = OCA.Files.App.getCurrentFileList().getCurrentDirectory()
 				OCA.Files.App.fileList.changeDirectory(currentDir, true, true)
 
-				showSuccess(t('files_scripts', 'Action completed!'))
+				for (let message of response.messages) {
+					messages.push({
+						message: message.text,
+						type: getMessageType(message.type)
+					} as Message)
+				}
+				messages = response.messages ?? []
+				messages.push({ message: (t('files_scripts', 'Action completed!')), type: MessageType.SUCCESS })
 				this.closeModal()
 			} catch (response) {
 				const errorObj = response?.response?.data
 				const errorMsg = (errorObj && errorObj.error) ? errorObj.error : t('files_scripts', 'Action failed unexpectedly.')
-				showError(errorMsg)
+
+				messages = errorObj.messages ?? []
+				messages.push({ message: errorMsg, type: MessageType.ERROR })
 			}
 			this.isRunning = false
+
+			for (let message of messages) {
+				showMessage(message);
+			}
 		},
 
 		async pickOutputDirectory() {


### PR DESCRIPTION
Add ability to return custom messages to the user (beyond the abort message).
 - Messages are queued and shown in order to the user with `add_message`
 - Message queue can be cleared with `clear_messages`

Messages can be given a type, which affects the toast colour:
 - `"info"`
 - `"error"`
 - `"warning"`
 - `"success"`


![image](https://user-images.githubusercontent.com/3178979/226787280-6193e7ba-ca38-4033-9d77-897007366ac3.png)
