### PR TITLE
Bump version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.2.0
+
+### Added
+- Nextcloud 26 support
+- Custom messages with `add_message` and `clear_messages`
+- Limit actions to certain user-groups
+- Added `include` function to Scripting API
+
+### Changed
+- Fix example scripts not getting inputs
+- Fix incomplete log messages
+- Fixed occ commands not correctly parsing input
+- Fixed multi-select input not allowing selection
+- Fixed file-pick input default and start-browse location
+- `tag_file_unassign` now works on folders
+- `file_copy`/`file_move` now work on folders
+- Fixed `meta_data` crashing scripts on externally mounted folders
+- Updated multi-select Vue component
+
 ## 2.1.1
 ### Added
 - Added function `get_file_tags` @0xFaul

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@ Allows administrators to write small scripts which users can run through via the
 ⚠️**Attention** Scripts may modify and delete files permanently. Take care and make sure to read the documentation thoroughly before scripting.
 	]]></description>
 
-    <version>2.1.1</version>
+    <version>2.2.0</version>
 
 	<licence>agpl</licence>
 	<author mail="r.ferreira.fuentes@gmail.com" >Raul Ferreira Fuentes</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "files_scripts",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "files_scripts",
 	"description": "Nextcloud app for running custom scripts on files.",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"author": "Raul Ferreira Fuentes <r.ferreira.fuentes@gmail.com>",
 	"homepage": "https://github.com/",
 	"license": "agpl",


### PR DESCRIPTION
### Added
- Nextcloud 26 support
- Custom messages with `add_message` and `clear_messages`
- Limit actions to certain user-groups
- Added `include` function to Scripting API

### Changed
- Fix example scripts not getting inputs
- Fix incomplete log messages
- Fixed occ commands not correctly parsing input
- Fixed multi-select input not allowing selection
- Fixed file-pick input default and start-browse location
- `tag_file_unassign` now works on folders
- `file_copy`/`file_move` now work on folders
- Fixed `meta_data` crashing scripts on externally mounted folders
- Updated multi-select Vue component