### PR TITLE
Scripts on public shares

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -3,10 +3,12 @@
 namespace OCA\FilesScripts\AppInfo;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCA\Files_Sharing\Event\ShareLinkAccessedEvent;
 use OCA\FilesScripts\Interpreter\FunctionProvider;
 use OCA\FilesScripts\Interpreter\IFunctionProvider;
 use OCA\FilesScripts\Listener\LoadAdditionalListener;
 use OCA\FilesScripts\Listener\RegisterFlowOperationsListener;
+use OCA\FilesScripts\Listener\ShareLinkAccessedListener;
 use OCA\FilesScripts\Middleware\DefaultScriptsMiddleware;
 use OCA\FilesScripts\Service\Notifier;
 use OCP\AppFramework\App;
@@ -32,6 +34,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(RegisterOperationsEvent::class, RegisterFlowOperationsListener::class);
 		$context->registerMiddleware(DefaultScriptsMiddleware::class);
 		$context->registerNotifierService(Notifier::class);
+		$context->registerEventListener(ShareLinkAccessedEvent::class, ShareLinkAccessedListener::class);
 
 		$context->registerService(IFunctionProvider::class, function () {
 			return \OC::$server->get(FunctionProvider::class);

--- a/lib/Controller/ScriptController.php
+++ b/lib/Controller/ScriptController.php
@@ -84,16 +84,17 @@ class ScriptController extends Controller {
 		string $program,
 		bool $enabled,
 		array $limitGroups,
-		bool $requestDirectory
+		bool $requestDirectory,
+		bool $public
 	): Response {
 		$script = new Script();
 		$script->setTitle($title);
 		$script->setDescription($description);
 		$script->setProgram($program);
 		$script->setEnabled($enabled);
-		$script->setEnabled($enabled);
 		$script->setLimitGroupsArray($limitGroups);
 		$script->setRequestDirectory($requestDirectory);
+		$script->setPublic($public);
 
 		$errors = $this->scriptService->validate($script);
 		if ($errors) {
@@ -120,7 +121,8 @@ class ScriptController extends Controller {
 		string $program,
 		bool $enabled,
 		array $limitGroups,
-		bool $requestDirectory
+		bool $requestDirectory,
+		bool $public
 	): Response {
 		$script = $this->scriptMapper->find($id);
 		if (!$script) {
@@ -133,6 +135,7 @@ class ScriptController extends Controller {
 		$script->setEnabled($enabled);
 		$script->setLimitGroupsArray($limitGroups);
 		$script->setRequestDirectory($requestDirectory);
+		$script->setPublic($public);
 
 		$errors = $this->scriptService->validate($script);
 		if ($errors) {

--- a/lib/Controller/ScriptController.php
+++ b/lib/Controller/ScriptController.php
@@ -164,6 +164,10 @@ class ScriptController extends Controller {
 			return new JSONResponse(['error' => $this->l->t('Action does not exist or is disabled.')], Http::STATUS_NOT_FOUND);
 		}
 
+		if ($shareToken !== null && !$script->getPublic()) {
+			return new JSONResponse(['error' => $this->l->t('This action is not enabled on public shares.')], Http::STATUS_FORBIDDEN);
+		}
+
 		$filePaths = [];
 		foreach ($files as $file) {
 			$filePaths[] = $file['path'] . '/' . $file['name'];

--- a/lib/Controller/ScriptInputController.php
+++ b/lib/Controller/ScriptInputController.php
@@ -5,6 +5,7 @@ namespace OCA\FilesScripts\Controller;
 use OCA\FilesScripts\Db\ScriptInput;
 use OCA\FilesScripts\Db\ScriptInputMapper;
 use OCA\FilesScripts\Db\ScriptMapper;
+use OCA\FilesScripts\Service\PermissionService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
@@ -18,17 +19,20 @@ class ScriptInputController extends Controller {
 	private ScriptMapper $scriptMapper;
 	private ScriptInputMapper $scriptInputMapper;
 	private IL10N $l;
+	private PermissionService $permissionService;
 
 	public function __construct(
 		$appName,
 		IRequest $request,
 		ScriptMapper $scriptMapper,
 		ScriptInputMapper $scriptInputMapper,
+		PermissionService $permissionService,
 		IL10N $l
 	) {
 		parent::__construct($appName, $request);
 		$this->scriptMapper = $scriptMapper;
 		$this->scriptInputMapper = $scriptInputMapper;
+		$this->permissionService = $permissionService;
 		$this->l = $l;
 	}
 
@@ -41,8 +45,14 @@ class ScriptInputController extends Controller {
 
 	/**
 	 * @NoAdminRequired
+	 * @PublicPage
 	 */
 	public function getByScriptId($scriptId): Response {
+		$script = $this->scriptMapper->find($scriptId);
+		if (!$this->permissionService->isEnabledForUser($script)) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);;
+		}
+
 		return new DataResponse($this->scriptInputMapper->findAllByScriptId($scriptId));
 	}
 

--- a/lib/Db/Script.php
+++ b/lib/Db/Script.php
@@ -16,6 +16,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int getEnabled()
  * @method setLimitGroups(string $groups)
  * @method int getLimitGroups()
+ * @method setPublic(bool $public)
+ * @method bool getPublic()
  * @method setRequestDirectory(int $enabled)
  * @method int getRequestDirectory()
  */
@@ -26,6 +28,7 @@ class Script extends Entity implements JsonSerializable {
 	protected ?int $enabled = null;
 	protected ?string $limitGroups = null;
 	protected ?int $requestDirectory = null;
+	protected ?bool $public = null;
 
 	public function setLimitGroupsArray(array $groupsArray): void {
 		$groups = implode(",", $groupsArray) ?: '';
@@ -45,6 +48,7 @@ class Script extends Entity implements JsonSerializable {
 			'enabled' => $this->enabled,
 			'limitGroups' => $this->getLimitGroupsArray(),
 			'requestDirectory' => $this->requestDirectory,
+			'public' => $this->public,
 		];
 	}
 }

--- a/lib/Interpreter/Context.php
+++ b/lib/Interpreter/Context.php
@@ -17,13 +17,14 @@ class Context {
 	private ?string $targetDirectory;
 	private LuaWrapper $lua;
 
-	private array $messages = [];
+	private array $messages;
+	private ?int $permissionOverride;
 
 	public function __construct(
 		LuaWrapper $lua,
 		Folder $root,
 		array $input,
-		array $files,
+		array $files = [],
 		?string $targetDirectory = null
 	) {
 		$this->lua = $lua;
@@ -32,6 +33,7 @@ class Context {
 		$this->files = $files;
 		$this->targetDirectory = $targetDirectory;
 
+		$this->permissionOverride = null;
 		$this->messages = [];
 	}
 
@@ -61,7 +63,6 @@ class Context {
 		return null;
 	}
 
-
 	public function getLua(): LuaWrapper {
 		return $this->lua;
 	}
@@ -74,6 +75,10 @@ class Context {
 		return $this->input;
 	}
 
+	public function getPermissionsOverride(): ?int {
+		return $this->permissionOverride;
+	}
+
 	/**
 	 * @return Node[]
 	 */
@@ -83,5 +88,9 @@ class Context {
 
 	public function getMessages(): array {
 		return $this->messages;
+	}
+
+	public function setPermissionsOverride(int $permissions): void {
+		$this->permissionOverride = $permissions;
 	}
 }

--- a/lib/Interpreter/ContextFactory.php
+++ b/lib/Interpreter/ContextFactory.php
@@ -1,0 +1,88 @@
+<?php
+namespace OCA\FilesScripts\Interpreter;
+
+use OCA\FilesScripts\Interpreter\Lua\LuaProvider;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Share\IManager;
+use Psr\Log\LoggerInterface;
+
+class ContextFactory {
+	private IRootFolder $rootFolder;
+	private LuaProvider $luaProvider;
+	private IManager $shareManager;
+	private LoggerInterface $logger;
+
+	public function __construct(
+		IRootFolder $rootFolder,
+		LuaProvider $luaProvider,
+		IManager $shareManager,
+		LoggerInterface $logger
+	) {
+		$this->rootFolder = $rootFolder;
+		$this->luaProvider = $luaProvider;
+		$this->shareManager = $shareManager;
+		$this->logger = $logger;
+	}
+
+	public function createContext(Folder $root, array $scriptInputs, array $filePaths): ?Context {
+		$files = [];
+		$n = 1;
+		foreach ($filePaths as $filePath) {
+			try {
+				$file = $root->get($filePath);
+			} catch (\Exception $e) {
+				$this->logger->error('Could not find input file belonging in root folder for file action', [
+					'root' => $root->getPath(),
+					'path' => $filePath
+				]);
+				return null;
+			}
+			$files[$n++] = $file;
+		}
+
+		return new Context($this->luaProvider->createLua(), $root, $scriptInputs, $files);
+	}
+
+	public function createContextForShare(string $shareToken, array $scriptInputs, array $filePaths): ?Context {
+		try {
+			$share = $this->shareManager->getShareByToken($shareToken);
+			$shareFolder = $share->getNode();
+
+			if (!$shareFolder instanceof \OC\Files\Node\Folder) {
+				$this->logger->error("Blocked attempt to run file action with share token for a file (folder expected).", [
+					"shareToken" => $shareToken
+				]);
+				return null;
+			}
+		} catch (\Exception $e) {
+			$this->logger->error("Failed to initialize share file action context.", [
+				"exception_message" => $e->getMessage(),
+				"exception_trace" => $e->getTraceAsString(),
+				"shareToken" => $shareToken
+			]);
+			return null;
+		}
+
+		$context = $this->createContext($shareFolder, $scriptInputs, $filePaths);
+		$context->setPermissionsOverride($share->getPermissions());
+
+		return $context;
+	}
+
+
+	public function createContextForUser(string $userId, array $scriptInputs, $filePaths): ?Context {
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($userId);
+		} catch(\Exception $e) {
+			$this->logger->error("Failed to initialize user file action context.", [
+				"exception_message" => $e->getMessage(),
+				"exception_trace" => $e->getTraceAsString(),
+				"userId" => $userId
+			]);
+			return null;
+		}
+
+		return $this->createContext($userFolder, $scriptInputs, $filePaths);
+	}
+}

--- a/lib/Listener/ShareLinkAccessedListener.php
+++ b/lib/Listener/ShareLinkAccessedListener.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\FilesScripts\Listener;
+
+use OCA\Files_Sharing\Event\ShareLinkAccessedEvent;
+use OCA\FilesScripts\AppInfo\Application;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+class ShareLinkAccessedListener implements IEventListener {
+	private IInitialState $initialStateService;
+
+	public function __construct(
+		IInitialState $initialStateService
+	) {
+		$this->initialStateService = $initialStateService;
+	}
+	public function handle(Event $event): void {
+		if (!($event instanceof ShareLinkAccessedEvent)) {
+			return;
+		}
+
+		$this->initialStateService->provideInitialState('actions_in_menu', false);
+
+		Util::addStyle(Application::APP_ID, 'global');
+		Util::addScript(Application::APP_ID, 'files_scripts-main');
+	}
+}

--- a/lib/Migration/Version030000Date20230423.php
+++ b/lib/Migration/Version030000Date20230423.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OCA\FilesScripts\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use Psr\Log\LoggerInterface;
+
+class Version030000Date20230423 extends SimpleMigrationStep {
+	private LoggerInterface $logger;
+
+	public function __construct(LoggerInterface $logger) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('filescripts')) {
+			$table = $schema->getTable('filescripts');
+
+			$table->addColumn('public', 'boolean', [
+				'notnull' => false,
+				'default' => false
+			]);
+		} else {
+			$this->logger->error('File scripts (Version030000Date20230323) migration failed, because `filescripts` table does not exist.');
+		}
+		return $schema;
+	}
+}

--- a/lib/Service/PermissionService.php
+++ b/lib/Service/PermissionService.php
@@ -27,9 +27,13 @@ class PermissionService {
 	 * Checks if the given script is allowed to be executed by the current user.
 	 */
 	public function isEnabledForUser(Script $script): bool {
-		$user = $this->userSession->getUser();
 		if (!$script->getEnabled()) {
 			return false;
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return $script->getPublic(); // No user => Only public scripts
 		}
 
 		$limitGroups = $script->getLimitGroupsArray();

--- a/src/api/script.ts
+++ b/src/api/script.ts
@@ -30,7 +30,10 @@ export const api = {
 	},
 
 	async runScript(script: Script, outputDirectory: string, inputs: ScriptInput[], files: any[]): Promise<any> {
-		return (await axios.post(generateUrl('/apps/files_scripts/run/' + script.id), { outputDirectory, inputs, files })).data
+		const shareToken = (<HTMLInputElement>document.getElementById('sharingToken'))?.value ?? null
+		const data = { outputDirectory, inputs, files, shareToken }
+
+		return (await axios.post(generateUrl('/apps/files_scripts/run/' + script.id), data)).data
 	},
 
 	async getScriptInputs(scriptId: Number): Promise<ScriptInput[]> {

--- a/src/components/ScriptEdit.vue
+++ b/src/components/ScriptEdit.vue
@@ -37,6 +37,10 @@
 					</NcNoteCard>
 				</template>
 
+				<NcCheckboxRadioSwitch type="switch" :checked="!!script.public" @update:checked="togglePublic">
+					{{ t('files_scripts', 'Allow on public shares') }}
+				</NcCheckboxRadioSwitch>
+
 				<NcCheckboxRadioSwitch type="switch" :checked.sync="limitGroupsEnabled" @update:checked="toggleLimitGroupsEnabled">
 					{{ t('files_scripts', 'Limit to groups') }}
 				</NcCheckboxRadioSwitch>
@@ -227,6 +231,9 @@ export default {
 		},
 		toggleRequestDirectory() {
 			this.$store.commit('selectedToggleValue', 'requestDirectory')
+		},
+		togglePublic() {
+			this.$store.commit('selectedToggleValue', 'public')
 		},
 		toggleLimitGroupsEnabled() {
 			if (!this.limitGroupsEnabled) {

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,84 +1,61 @@
 import { translate as t } from './l10n'
 
+export function reloadCurrentDirectory() {
+	const fileList = OCA.Files?.App?.fileList ?? OCA?.Sharing?.PublicApp?.fileList
+	if (!fileList) {
+		return
+	}
+	fileList.changeDirectory(fileList.getCurrentDirectory(), true, true)
+}
+
+function buildActionObject(myHandler, script=null) {
+	const displayName = script ? script.title : t('files_scripts', 'More actions')
+	let name = 'files_scripts_action'
+	if (script) {
+		name += script.id
+	}
+
+	return {
+		name,
+		displayName,
+		mime: 'all',
+		permissions: OC.PERMISSION_READ,
+		order: 1001,
+		iconClass: 'icon-files_scripts',
+
+		// For multi-file picker
+		action: (files) => {
+			myHandler(files, script)
+		},
+		// For single-file picker
+		actionHandler: (filePath, context) => {
+			const file = context?.fileInfoModel?.attributes
+			file && myHandler([file], script)
+		},
+	}
+}
+
 /**
  * Registers the action handler for the multi select actions menu.
  *
  * @param {Function} action Callback to the handler
+ * @param {Script|null} script the script which will be run as part of the action (or none specified)
  */
-export function registerMultiSelect(action) {
-	const actionObj = {
-		name: 'files_scripts_multi_action',
-		displayName: t('files_scripts', 'More actions'),
-		iconClass: 'icon-files_scripts',
-		order: 1001,
-		action,
+export function registerMenuOptions(action, script=null) {
+	const actionObject = buildActionObject(action, script)
+	if (OCA.Files && OCA.Files.App && OCA.Files.App.fileList) {
+		OCA.Files.App.fileList.registerMultiSelectFileAction(actionObject)
 	}
 
-	if (OCA.Files.App.fileList) {
-		OCA.Files.App.fileList.registerMultiSelectFileAction(actionObj)
-	} else {
-		OC.Plugins.register('OCA.Files.FileList', {
-			attach(fileList) {
-				fileList.registerMultiSelectFileAction(actionObj)
-			},
-		})
-	}
-}
-
-/**
- * Registers the action handler on the file context menu.
- *
- * @param {Function} actionHandler Callback to the handler
- */
-export function registerFileSelect(actionHandler) {
-	OCA.Files.fileActions.registerAction({
-		name: 'files_scripts_action',
-		displayName: t('files_scripts', 'More actions'),
-		mime: 'all',
-		permissions: OC.PERMISSION_READ,
-		iconClass: 'icon-files_scripts',
-		actionHandler,
-	})
-}
-
-/**
- * Registers the action handler on the file context menu.
- *
- * @param {Script} script unique id to identify menu item
- * @param {Function} actionHandler Callback to the handler
- */
-export function registerFileSelectDirect(script, actionHandler) {
-	OCA.Files.fileActions.registerAction({
-		name: 'files_scripts_action' + script.id,
-		displayName: script.title,
-		mime: 'all',
-		permissions: OC.PERMISSION_READ,
-		iconClass: 'icon-files_scripts',
-		actionHandler,
-	})
-}
-/**
- * Registers the multi-select action handler directly on the file context menu.
- *
- * @param {Script} script unique id to identify menu item
- * @param {Function} action Callback to the handler
- */
-export function registerMultiSelectDirect(script, action) {
-	const actionObj = {
-		name: 'files_scripts_multi_action' + script.id,
-		displayName: script.title,
-		iconClass: 'icon-files_scripts',
-		order: 1000,
-		action,
+	if (OCA.Files && OCA.Files.fileActions) {
+		OCA.Files.fileActions.registerAction(actionObject)
 	}
 
-	if (OCA.Files.App.fileList) {
-		OCA.Files.App.fileList.registerMultiSelectFileAction(actionObj)
-	} else {
-		OC.Plugins.register('OCA.Files.FileList', {
-			attach(fileList) {
-				fileList.registerMultiSelectFileAction(actionObj)
-			},
-		})
-	}
+	// Public share multiselect, wait two seconds to make sure the fileList is initialized
+	setTimeout(() => {
+		if (OCA.Sharing && OCA.Sharing.PublicApp && OCA.Sharing.PublicApp.fileList) {
+			OCA.Sharing.PublicApp.fileList.registerMultiSelectFileAction(actionObject)
+		}
+	}, 2000)
 }
+

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -6,6 +6,7 @@ export interface Script {
 	enabled: boolean
 	requestDirectory: boolean
 	limitGroups: string[]
+	public: boolean
 }
 
 export interface ScriptInput {
@@ -34,6 +35,7 @@ export function defaultScript(): Script {
 		enabled: false,
 		program: '',
 		requestDirectory: false,
+		public: false,
 		limitGroups: []
 	}
 }


### PR DESCRIPTION
Resolves #31 

Adds an option to make scripts available to public shares. This only works for folder shares, and the shared folder is set as the `root()` directory for the script.