### PR TITLE
Fix file_move_unsafe, adds file_delete_unsafe

### DIFF
--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -84,11 +84,17 @@ jobs:
           ./occ config:system:set --value="http://localhost:8080" -- overwrite.cli.url
           ./occ app:enable --force ${{ env.APP_NAME }}
           for user in alice bob jane john; do \
-          OC_PASS="$user" ./occ user:add --password-from-env "$user"; \
+            OC_PASS="$user" ./occ user:add --password-from-env "$user"; \
           done
 
       - name: Run Nextcloud
         run: php -S localhost:8080 &
+
+      - name: Initialise users
+        run: |
+          for user in alice bob jane john; do \
+            curl -u $user:$user http://localhost:8080/index.php; \
+          done
 
       - name: Behat integration
         working-directory: apps/${{ env.APP_NAME }}

--- a/lib/Interpreter/FunctionProvider.php
+++ b/lib/Interpreter/FunctionProvider.php
@@ -2,6 +2,7 @@
 
 namespace OCA\FilesScripts\Interpreter;
 
+use OCA\FilesScripts\Interpreter\Functions\Files\File_Delete_Unsafe;
 use OCA\FilesScripts\Interpreter\Functions\Output\Abort;
 use OCA\FilesScripts\Interpreter\Functions\Output\Add_Message;
 use OCA\FilesScripts\Interpreter\Functions\Output\Clear_Messages;
@@ -123,7 +124,8 @@ class FunctionProvider implements IFunctionProvider {
 		Shares_Find $f59,
 		Share_File $f60,
 		Share_Delete $f62,
-		View_Files $f63
+		View_Files $f63,
+		File_Delete_Unsafe $f64
 	) {
 		$this->functions = func_get_args();
 	}

--- a/lib/Interpreter/Functions/Files/File_Delete_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/File_Delete_Unsafe.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+use Exception;
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+use OCP\Files\IRootFolder;
+
+/**
+ * `file_delete_unsafe(String path, [Bool success_if_not_found]=true): Bool`
+ *
+ * Deletes a file/folder node in the given path.
+ * By default, the function also returns true if the file was not found. This behaviour can be changed by setting its second argument to `false`.
+ *
+ * ⚠️ Use of this function is strongly discouraged as it may allow users to delete files from other users.
+ */
+class File_Delete_Unsafe extends RegistrableFunction {
+	private IRootFolder $root;
+
+	public function __construct(IRootFolder $root) {
+		$this->root = $root;
+	}
+
+	public function run($path = null, $successIfNotFound = true): bool {
+		try {
+			$file = $this->root->get($path);
+		} catch (\Exception|\Throwable $e) {
+			$file = null;
+		}
+
+		if (!$file) {
+			return (bool) $successIfNotFound;
+		}
+
+		try {
+			$file->delete();
+		} catch (Exception $e) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/lib/Interpreter/Functions/Files/File_Move.php
+++ b/lib/Interpreter/Functions/Files/File_Move.php
@@ -2,8 +2,9 @@
 
 namespace OCA\FilesScripts\Interpreter\Functions\Files;
 
-use Exception;
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 
 /**
  * `file_move(Node file, [String folder = nil], [String new_name = nil]): Node|null`
@@ -16,7 +17,7 @@ use OCP\Files\IRootFolder;
  *
  * Returns the resulting file, or `nil` if the operation failed.
  */
-class File_Move extends File_Move_Unsafe {
+class File_Move extends RegistrableFunction {
 	private IRootFolder $rootFolder;
 
 	public function __construct(IRootFolder $rootFolder) {
@@ -43,8 +44,21 @@ class File_Move extends File_Move_Unsafe {
 
 		try {
 			$destination = $this->rootFolder->getRelativePath($folderNode->getPath());
-			return parent::run($file, $destination, $newName);
-		} catch (Exception $e) {
+			$newFile = $this->fileMove($fileNode, $destination, $newName);
+
+			return $this->getNodeData($newFile);
+		} catch (\Exception $e) {
+			return null;
+		}
+	}
+
+	protected function fileMove(Node $fileNode, string $destinationFolder, $newName): ?Node {
+		$newName = (is_string($newName) && strlen($newName) > 0) ? $newName : $fileNode->getName();
+		$destinationPath = $destinationFolder . '/' . $newName;
+		try {
+			$newFileNode = $fileNode->move($destinationPath);
+			return ($newFileNode);
+		} catch (\Throwable|\Exception $e) {
 			return null;
 		}
 	}

--- a/lib/Interpreter/Functions/Files/File_Move_Unsafe.php
+++ b/lib/Interpreter/Functions/Files/File_Move_Unsafe.php
@@ -2,8 +2,7 @@
 
 namespace OCA\FilesScripts\Interpreter\Functions\Files;
 
-use OCA\FilesScripts\Interpreter\RegistrableFunction;
-use Throwable;
+use OCP\Files\Node;
 
 /**
  * `file_move_unsafe(Node file, [String folder = nil], [String new_name = nil]): Node|null`
@@ -19,7 +18,9 @@ use Throwable;
  * file_move_unsafe(file, "alice/files/inbox", "message.txt")
  * ```
  */
-class File_Move_Unsafe extends RegistrableFunction {
+class File_Move_Unsafe extends File_Move {
+	use UnsafeViewOperationTrait;
+
 	public function run(
 		$file = null,
 		$folderPath = null,
@@ -30,14 +31,49 @@ class File_Move_Unsafe extends RegistrableFunction {
 			return null;
 		}
 
-		$newName = $newName ?: $fileNode->getName();
-		$destination = $folderPath . '/' . $newName;
+		$newFile = $this->tryUnsafeOperation(function () use ($fileNode, $folderPath, $newName): Node {
+			return $this->fileMove($fileNode, $folderPath, $newName);
+		});
+
+		if ($newFile instanceof Node) {
+			return $this->getNodeData($newFile);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Hack alert!
+	 * This hack was introduced, following nextcloud/server commit 55d943fd4b35c9df3e3639d6f264e4f8d8df82f0
+	 *
+	 * In this commit the defaultInstance is initialised to the user's home path instead of the server root.
+	 *
+	 * In order to trick Nextcloud into moving files to another user's home directory we need to set the defaultInstance
+	 * of the Filesystem to the root view (path: `/`). This will be used during the `node->move()` method to evaluate the
+	 * relative paths of the two files.
+	 *
+	 * @see \OC\Files\View::rename
+	 * @see \OC\Files\View::getHookPath
+	 */
+	private function tryMoveWithDefaultInstanceOverride(Node $fileNode, string $destinationPath): ?Node {
+		$defaultInstance = null;
 
 		try {
-			$newFileNode = $fileNode->move($destination);
-			return $this->getNodeData($newFileNode);
-		} catch (Throwable $e) {
+			$class = \OC\Files\Filesystem::class;
+			$reflection = new ReflectionClass($class);
+
+			$property = $reflection->getProperty("defaultInstance");
+			$property->setAccessible(true);
+
+			$defaultInstance = $reflection->getStaticPropertyValue("defaultInstance");
+			$reflection->setStaticPropertyValue('defaultInstance', new \OC\Files\View('/'));
+
+			return $fileNode->move($destinationPath);
+		} catch (\Exception|\Throwable $e) {
 			return null;
+		} finally {
+			// Set the defaultInstance back to the previous value.
+			isset($reflection) && $reflection->setStaticPropertyValue('defaultInstance', $defaultInstance);
 		}
 	}
 }

--- a/lib/Interpreter/Functions/Files/UnsafeViewOperationTrait.php
+++ b/lib/Interpreter/Functions/Files/UnsafeViewOperationTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Files;
+
+use ReflectionClass;
+
+trait UnsafeViewOperationTrait {
+	/**
+	 * Hack alert!
+	 * This hack was introduced, following nextcloud/server commit 55d943fd4b35c9df3e3639d6f264e4f8d8df82f0
+	 *
+	 * In this commit the defaultInstance is initialised to the user's home path instead of the server root.
+	 *
+	 * In order to trick Nextcloud into moving files to another user's home directory we need to set the defaultInstance
+	 * of the Filesystem to the root view (path: `/`). This will be used during the `node->move()` method to evaluate the
+	 * relative paths of the two files.
+	 *
+	 * @see \OC\Files\View::rename
+	 * @see \OC\Files\View::getHookPath
+	 */
+	protected function tryUnsafeOperation(callable $operation) {
+		$defaultInstance = null;
+
+		try {
+			$class = \OC\Files\Filesystem::class;
+			$reflection = new ReflectionClass($class);
+
+			$property = $reflection->getProperty("defaultInstance");
+			$property->setAccessible(true);
+
+			$defaultInstance = $reflection->getStaticPropertyValue("defaultInstance");
+			$reflection->setStaticPropertyValue('defaultInstance', new \OC\Files\View('/'));
+
+			return $operation();
+		} catch (\Exception|\Throwable $e) {
+			return null;
+		} finally {
+			// Set the defaultInstance back to the previous value.
+			isset($reflection) && $reflection->setStaticPropertyValue('defaultInstance', $defaultInstance);
+		}
+	}
+}

--- a/tests/integration/features/fixtures/test_files.lua
+++ b/tests/integration/features/fixtures/test_files.lua
@@ -73,3 +73,44 @@ assertNotNil(meta_hello_world["can_delete"])
 assertNotNil(meta_hello_world["can_update"])
 assertNotNil(meta_hello_world["local_path"])
 assertNotNil(meta_hello_world["owner_id"])
+
+-- Test copy unsafe function
+file_delete_unsafe("/alice/files/foo.txt") -- make sure file doesnt exist
+assertFalse(exists_unsafe('/alice/files/foo.txt'), "unexpected file `foo.txt` in `/alice/files/`")
+file_delete_unsafe("/alice/files/bar.txt") -- make sure file doesnt exist
+assertFalse(exists_unsafe('/alice/files/bar.txt'), "unexpected file `bar.txt` in `/alice/files/`")
+
+file = new_file(home(), "foo.txt")
+
+result = file_copy_unsafe(file, '/alice/files/')
+assertNotNil(result)
+assertTrue(exists_unsafe('/alice/files/foo.txt'), "expected file `foo.txt` in `/alice/files/`")
+
+result = file_copy_unsafe(file, '/alice/files/', 'bar.txt')
+assertNotNil(result)
+assertTrue(exists_unsafe('/alice/files/bar.txt'), "expected file `bar.txt` in `/alice/files/`")
+
+
+-- Test move unsafe function
+file_delete_unsafe("/alice/files/foo.txt") -- make sure file doesnt exist
+assertFalse(exists_unsafe('/alice/files/foo.txt'), "unexpected file `foo.txt` in `/alice/files/`")
+file = new_file(home(), "foo.txt")
+result = file_move_unsafe(file, '/alice/files/')
+assertNotNil(result)
+assertTrue(exists_unsafe('/alice/files/foo.txt'), "expected file `foo.txt` in `/alice/files/`")
+
+
+file_delete_unsafe("/alice/files/bar.txt") -- make sure file doesnt exist
+assertFalse(exists_unsafe('/alice/files/bar.txt'), "unexpected file `bar.txt` in `/alice/files/`")
+file = new_file(home(), "foo.txt")
+result = file_move_unsafe(file, '/alice/files/', 'bar.txt')
+assertNotNil(result)
+assertTrue(exists_unsafe('/alice/files/bar.txt'), "expected file `bar.txt` in `/alice/files/`")
+
+-- Check file_delete_unsafe works
+success = file_delete_unsafe("/alice/files/bar.txt", false)
+assertTrue(success)
+assertFalse(exists_unsafe('/alice/files/bar.txt'), "unexpected file `bar.txt` in `/alice/files/`, after deletion")
+
+success = file_delete_unsafe("/alice/files/bar.txt", false)
+assertFalse(success)


### PR DESCRIPTION
Addresses: https://github.com/Raudius/files_scripts/issues/103

In this PR:
- Fixes `file_move_unsafe` function which was broken by upstream changes (in-detail explanation in code-comments)
- Adds `file_delete_unsafe` function to also facilitate integration test
- Adds integration tests for "unsafe' functions