### PR TITLE
Add import and export script comands

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,6 +40,7 @@ Allows administrators to write small scripts which users can run through via the
 		<command>OCA\FilesScripts\Command\RunScript</command>
 		<command>OCA\FilesScripts\Command\ListScripts</command>
 		<command>OCA\FilesScripts\Command\ExportScripts</command>
+		<command>OCA\FilesScripts\Command\ImportScripts</command>
 	</commands>
 	<settings>
 		<admin>OCA\FilesScripts\Settings\AdminSettings</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,6 +39,7 @@ Allows administrators to write small scripts which users can run through via the
 	<commands>
 		<command>OCA\FilesScripts\Command\RunScript</command>
 		<command>OCA\FilesScripts\Command\ListScripts</command>
+		<command>OCA\FilesScripts\Command\ExportScripts</command>
 	</commands>
 	<settings>
 		<admin>OCA\FilesScripts\Settings\AdminSettings</admin>

--- a/lib/Command/ExportScripts.php
+++ b/lib/Command/ExportScripts.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ExportScripts extends Base {
 	private ScriptMapper $scriptMapper;
+	private ScriptService $scriptService;
 
 	public function __construct(
 		ScriptMapper $scriptMapper,
@@ -20,7 +21,7 @@ class ExportScripts extends Base {
 	}
 
 	protected function configure(): void {
-		$this->setDescription('Exports file actions');
+		$this->setDescription('Exports file actions as JSON');
 		parent::configure();
 	}
 

--- a/lib/Command/ExportScripts.php
+++ b/lib/Command/ExportScripts.php
@@ -1,0 +1,57 @@
+<?php
+namespace OCA\FilesScripts\Command;
+
+use OC\Core\Command\Base;
+use OCA\FilesScripts\Db\ScriptMapper;
+use OCA\FilesScripts\Service\ScriptService;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExportScripts extends Base {
+	private ScriptMapper $scriptMapper;
+
+	public function __construct(
+		ScriptMapper $scriptMapper,
+		ScriptService $scriptService
+	)  {
+		parent::__construct('files_scripts:export');
+		$this->scriptMapper = $scriptMapper;
+		$this->scriptService = $scriptService;
+	}
+
+	protected function configure(): void {
+		$this->setDescription('Exports file actions');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output)  {
+		$scriptId = $input->hasArgument("id")
+			? intval($input->getArgument('id'))
+			: null;
+		if ($scriptId !== null) {
+			$json = $this->exportScript($scriptId);
+		} else {
+			$json = $this->exportAllScripts();
+		}
+
+		$output->writeln($json);
+		return 0;
+	}
+
+	private function exportScript(int $scriptId) {
+		$script = $this->scriptMapper->find($scriptId);
+		$scriptJson = $this->scriptService->scriptToJson($script);
+		return json_encode($scriptJson) ?: '';
+	}
+
+
+	private function exportAllScripts(): string {
+		$allScriptsJson = [];
+		$scripts = $this->scriptMapper->findAll();
+		foreach ($scripts as $script) {
+			$allScriptsJson[] = $this->scriptService->scriptToJson($script);
+		}
+
+		return json_encode($allScriptsJson) ?: "";
+	}
+}

--- a/lib/Command/ImportScripts.php
+++ b/lib/Command/ImportScripts.php
@@ -1,0 +1,64 @@
+<?php
+namespace OCA\FilesScripts\Command;
+
+use OC\Core\Command\Base;
+use OCA\FilesScripts\Db\ScriptMapper;
+use OCA\FilesScripts\Service\ScriptService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ImportScripts extends Base {
+	private ScriptMapper $scriptMapper;
+	private ScriptService $scriptService;
+
+	private LoggerInterface $logger;
+
+	public function __construct(
+		ScriptMapper $scriptMapper,
+		ScriptService $scriptService,
+		LoggerInterface $logger
+	)  {
+		parent::__construct('files_scripts:import');
+		$this->scriptMapper = $scriptMapper;
+		$this->scriptService = $scriptService;
+		$this->logger = $logger;
+	}
+
+	protected function configure(): void {
+		$this->setDescription('Imports file actions from JSON');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output)  {
+		$json = file_get_contents("php://stdin");
+		if (false === $json) {
+			$output->writeln('<error>You need an interactive terminal to run this command</error>');
+			return false;
+		}
+
+		$jsonData = json_decode($json, true);
+		$isSingleScript = isset($scriptData[0]);
+		if ($isSingleScript) {
+			$jsonData = [$jsonData];
+		}
+
+		foreach ($jsonData as $scriptData) {
+			try {
+				$script = $this->scriptService->createScriptFromJson($scriptData);
+				$output->writeln('<info>Imported script: ' . $script->getTitle() . '</info>');
+			} catch (\Exception $e) {
+				$output->writeln('<info>FAILED TO IMPORT SCRIPT: ' . ($scriptData['title'] ?? '<unknown-title>') . '</info>');
+				$this->logger->warning('Failed to import script', [
+					'script_data' => $scriptData,
+					'error_message' => $e->getMessage(),
+					'error_trace' => $e->getTraceAsString()
+				]);
+			}
+		}
+
+		$output->writeln($json);
+		return 0;
+	}
+
+}

--- a/lib/Db/Script.php
+++ b/lib/Db/Script.php
@@ -39,6 +39,27 @@ class Script extends Entity implements JsonSerializable {
 		return array_filter(explode(",", $this->limitGroups) ?: []);
 	}
 
+	public static function newFromJson(array $jsonData): Script {
+		$script = new Script();
+		$script->setTitle($jsonData["title"] ?? "");
+		$script->setDescription($jsonData["description"] ?? "");
+		$script->setProgram($jsonData["program"] ?? "");
+		$script->setMimetype($jsonData["mimetype"] ?? "");
+
+		$enabled = $jsonData["enabled"] ?? 0;
+		$enabled = is_integer($enabled) ? $enabled : 0;
+		$script->setEnabled($enabled);
+
+		$public = $jsonData["public"] ?? 0;
+		if (!is_integer($public)) {
+			$public = 0;
+		}
+		$script->setPublic($public);
+
+
+		return $script;
+	}
+
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,

--- a/lib/Db/ScriptInput.php
+++ b/lib/Db/ScriptInput.php
@@ -24,6 +24,17 @@ class ScriptInput extends Entity implements JsonSerializable {
 
 	protected $value = null;
 
+	public static function newFromJson($jsonData): ScriptInput {
+		$scriptInput = new ScriptInput();
+
+		$scriptInput->setName($jsonData["name"] ?? "");
+		$scriptInput->setDescription($jsonData["description"] ?? "");
+
+		$options = $jsonData["options"] ?? [];
+		$options = is_array($options) ? $options : [];
+		$scriptInput->setScriptOptions($options);
+	}
+
 	public function jsonSerialize(): array {
 		return [
 			'id' => $this->id,

--- a/lib/Db/ScriptInput.php
+++ b/lib/Db/ScriptInput.php
@@ -33,6 +33,8 @@ class ScriptInput extends Entity implements JsonSerializable {
 		$options = $jsonData["options"] ?? [];
 		$options = is_array($options) ? $options : [];
 		$scriptInput->setScriptOptions($options);
+
+		return $scriptInput;
 	}
 
 	public function jsonSerialize(): array {

--- a/lib/Db/ScriptMapper.php
+++ b/lib/Db/ScriptMapper.php
@@ -10,7 +10,7 @@ use OCP\IDBConnection;
 /**
  * @method Script findBy(string $column, string $value)
  * @method Script[] findAllBy(string $column, string $value)
- * @method Script find(int $id)
+ * @method Script|null find(int $id)
  * @method Script[] findAll()
  */
 class ScriptMapper extends BaseMapper {

--- a/lib/Middleware/DefaultScriptsMiddleware.php
+++ b/lib/Middleware/DefaultScriptsMiddleware.php
@@ -4,86 +4,27 @@ namespace OCA\FilesScripts\Middleware;
 
 use OCA\FilesScripts\AppInfo\Application;
 use OCA\FilesScripts\Controller\ScriptController;
-use OCA\FilesScripts\Db\Script;
-use OCA\FilesScripts\Db\ScriptInput;
-use OCA\FilesScripts\Db\ScriptInputMapper;
 use OCA\FilesScripts\Db\ScriptMapper;
+use OCA\FilesScripts\Service\ScriptService;
 use OCP\AppFramework\Middleware;
 use OCP\DB\Exception;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class DefaultScriptsMiddleware extends Middleware {
-	private const DEFAULT_SCRIPTS = [
-		[
-			'program' => '../../examples/business_card.lua',
-			'name' => 'Generate business card',
-			'description' => 'Generates a business card PDF. This script will create the file "business-card.pdf" in your home folder.',
-			'inputs' => [
-				'company_name' => 'Company name',
-				'phone' => 'Phone number',
-				'email' => 'Email address',
-				'name' => 'Full name',
-				'title' => [
-					'description' => 'Occupation',
-					'options' => [
-						'type' => 'multiselect',
-						'multiselectOptions' => [ 'Sales associate', 'Marketing', 'Software developer']
-					]
-				],
-				'website' => 'Web URL',
-			]
-		],
-		[
-			'program' => '../../examples/merge_pdfs.lua',
-			'name' => 'Merge PDFs',
-			'description' => 'Combines all the selected PDFs into a single file.',
-			'inputs' => [
-				'file_name' => 'Name of the output file',
-				'output_location' => [
-					'description' => 'Save location',
-					'options' => [
-						'type' => 'filepick',
-						'filepickMimes' => ['httpd/unix-directory']
-					]
-				]
-			],
-			'mimetype' => 'application/pdf',
-		],
-		[
-			'program' => '../../examples/directory_tree.lua',
-			'name' => 'Directory tree',
-			'description' => 'Creates a file "tree.txt" containing the recursive directory listing of the selected files and folders.',
-		],
-		[
-			'program' => '../../examples/generate_invoice.lua',
-			'name' => 'Generate invoice',
-			'description' => 'Creates an invoice from valid JSON files containing order data (see script comments for more details).',
-			'inputs' => [
-				'output_location' => [
-					'description' => 'Save location',
-					'options' => [
-						'type' => 'filepick',
-						'filepickMimes' => ['httpd/unix-directory']
-					]
-				]
-			]
-		],
-	];
-
+	private ScriptService $scriptService;
 	private ScriptMapper $scriptMapper;
 	private IConfig $config;
-	private ScriptInputMapper $scriptInputMapper;
 	private LoggerInterface $logger;
 
 	public function __construct(
+		ScriptService $scriptService,
 		ScriptMapper $scriptMapper,
-		ScriptInputMapper $scriptInputMapper,
 		IConfig $config,
 		LoggerInterface $logger
 	) {
 		$this->scriptMapper = $scriptMapper;
-		$this->scriptInputMapper = $scriptInputMapper;
+		$this->scriptService = $scriptService;
 		$this->config = $config;
 		$this->logger = $logger;
 	}
@@ -104,54 +45,30 @@ class DefaultScriptsMiddleware extends Middleware {
 			return;
 		}
 
+		$scriptsJson = file_get_contents(__DIR__ . '/examples.json');
+		if (!$scriptsJson) {
+			$this->logger->warning('Could not create default scripts, examples.json not found.');
+			return;
+		}
+
+		$scriptsJsonData = json_decode($scriptsJson, true);
+		if (!$scriptsJsonData) {
+			$this->logger->warning('Could not create default scripts, could not decode JSON.');
+			return;
+		}
 		$this->config->setAppValue(Application::APP_ID, Application::APP_CONFIG_FIRST_RUN, 'false');
 
-		foreach (self::DEFAULT_SCRIPTS as $scriptData) {
+		foreach ($scriptsJsonData as $scriptData) {
 			try {
-				$this->createDefaultScript($scriptData);
+				$this->scriptService->createScriptFromJson($scriptData);
 			} catch (Exception $e) {
 				$this->logger->error('Files scripts could not create default script', [
 					'error_message' => $e->getMessage(),
 					'trace' => $e->getTraceAsString(),
-					'script' => $scriptData['name']
+					'script' => $scriptData['title'] ?? 'unknown title',
+					'script_data' => $scriptData,
 				]);
 			}
-		}
-	}
-
-	/**
-	 * @param array $scriptData
-	 * @return void
-	 * @throws Exception
-	 */
-	private function createDefaultScript(array $scriptData): void {
-		$program = file_get_contents(__DIR__ . '/' .$scriptData['program']) ?: null;
-		if (!$program) {
-			return;
-		}
-
-		$script = new Script();
-		$script->setProgram($program);
-		$script->setEnabled(false);
-		$script->setTitle($scriptData['name']);
-		$script->setDescription($scriptData['description']);
-		$script->setMimetype($scriptData['mimetype'] ?? '');
-
-		$script = $this->scriptMapper->insert($script);
-
-		$inputData = $scriptData['inputs'] ?? [];
-		foreach ($inputData as $name => $data) {
-			if (is_string($data)) {
-				$data = [ 'description' => $data ];
-			}
-
-			$scriptInput = new ScriptInput();
-			$scriptInput->setScriptId($script->getId());
-			$scriptInput->setName($name);
-			$scriptInput->setDescription($data['description']);
-			$scriptInput->setScriptOptions($data['options'] ?? []);
-
-			$this->scriptInputMapper->insert($scriptInput);
 		}
 	}
 }

--- a/lib/Middleware/examples.json
+++ b/lib/Middleware/examples.json
@@ -1,0 +1,107 @@
+[
+	{
+		"title": "Generate business card",
+		"description": "Generates a business card PDF. This script will create the file \"business-card.pdf\" in your home folder.",
+		"program": "--- Creates a simple business card PDF from a Mustache HTML template.\n--- The PDF is saved to the user's home directory with the name \"business-card.pdf\"\n---\n--- This action does not currently do anything with the selected files, ideally either the\n--- html, or the vars would get loaded from a file:\n---\n--- html = file_content(get_input_files()[1])\n--- vars = json(file_content(get_input_files()[1]))\n\nvars = get_input()\nhtml = [[\n<div style=\"box-shadow: .5mm 1mm 2mm .5mm rgba(0,0,0,0.2); width: 90mm; height: 50mm;\">\n\t<div style=\"height: 16mm; text-align: center; font-size: 8mm; line-height: 15mm;\">\n\t\t<b>{{ company_name }}<b>\n\t</div>\n\t<div style=\"height: 28mm; text-align: center; font-size: 3mm; line-height: 4.5mm;\">\n        <div><b>{{ name }}</b></div>\n        <div><i>{{ title }}</i></div>\n        <div><br/></div>\n        <div>{{ phone }}</div>\n        <div >{{ email }}</div>\n\t</div>\n\t<div style=\"text-align: center; font-size: 3mm;\">{{ website }}</div>\n</div>\n]]\n\ncard = mustache(html, vars)\ncontent = html_to_pdf(card)\n\nif( exists(home(), \"business-card.pdf\") )then\n\tabort(\"File 'business-card.pdf' already exists in your home folder.\")\nend\n\nnew_file(home(), \"business-card.pdf\", content)\n",
+		"enabled": 0,
+		"limitGroups": [],
+		"public": 0,
+		"mimetype": "",
+		"inputs": [
+			{
+				"name": "company_name",
+				"description": "Company name",
+				"options": []
+			},
+			{
+				"name": "phone",
+				"description": "Phone number",
+				"options": []
+			},
+			{
+				"name": "email",
+				"description": "Email address",
+				"options": []
+			},
+			{
+				"name": "name",
+				"description": "Full name",
+				"options": []
+			},
+			{
+				"name": "title",
+				"description": "Occupation",
+				"options": {
+					"type": "multiselect",
+					"multiselectOptions": [
+						"Sales associate",
+						"Marketing",
+						"Software developer"
+					]
+				}
+			},
+			{
+				"name": "website",
+				"description": "Web URL",
+				"options": []
+			}
+		]
+	},
+	{
+		"title": "Merge PDFs",
+		"description": "Combines all the selected PDFs into a single file.",
+		"program": "--- Merges any selected PDF files to a single file in the selected location and with the provided name.\n--- PDFs are sorted by name in ascending order before they are merged.\n--- Non-PDF files will get ignored.\n---\n--- NOTE: This command requires `qpdf` to be installed on the server.\n--- https://github.com/qpdf/qpdf\n\nlocal dir = get_input(\"output_location\")\nlocal name = get_input(\"file_name\")\nlocal files = get_input_files()\n\nif (name == nil or name == \"\") then\n\tabort(\"No file name was provided\")\nend\n\nif (string.find(name, \".pdf\") == nil) then\n\tname = name .. \".pdf\"\nend\n\nif (exists(dir, name)) then\n\tabort(\"A file already exists in the chosen location\")\nend\n\nfiles = sort(files, \"name\")\n\npdf_merge(files, dir, name)\n",
+		"enabled": 0,
+		"limitGroups": [],
+		"public": 0,
+		"mimetype": "application/pdf",
+		"inputs": [
+			{
+				"name": "file_name",
+				"description": "Name of the output file",
+				"options": []
+			},
+			{
+				"name": "output_location",
+				"description": "Save location",
+				"options": {
+					"type": "filepick",
+					"filepickMimes": [
+						"httpd/unix-directory"
+					]
+				}
+			}
+		]
+	},
+	{
+		"title": "Directory tree",
+		"description": "Creates a file \"tree.txt\" containing the recursive directory listing of the selected files and folders.",
+		"program": "--- Crawls through the selected folders/files and crates a directory tree.\n---\n--- The directory tree gets saved to the directory from which the files were\n--- selected, with the name \"tree.txt\".\n\nfunction listing(nodes, separator)\n  separator = separator or \"\"\n  local files = \"\"\n  local folders = \"\"\n\n  for i, node in ipairs(nodes) do\n  \tif( is_file(node) )then\n      files = files .. separator .. \"-\" .. node.name .. \"\\n\"\n    elseif( is_folder(node) )then\n      local list = listing(directory_listing(node), separator .. \"\\t\")\n      folders = folders .. separator .. \"-[\" .. node.name .. \"]\\n\" .. list\n    end\n  end\n\n  return folders .. files\nend\n\nlocal list = listing(get_input_files(), \"\")\nlocal out_folder = get_parent(get_input_files()[1])\n\nif( exists(out_folder, \"tree.txt\") )then\n\tabort(\"The file 'tree.txt' already exists in this folder.\")\nend\n\nnew_file(out_folder, \"tree.txt\", list)\n",
+		"enabled": 0,
+		"limitGroups": [],
+		"public": 0,
+		"mimetype": "",
+		"inputs": []
+	},
+	{
+		"title": "Generate invoice",
+		"description": "Creates an invoice from valid JSON files containing order data (see script comments for more details).",
+		"program": "--- Generates an invoice from a JSON file containing the order data\n--- Sample JSON:\n--[[\n{\n\t\"invoice_number\": \"310887\",\n\t\"vat_percent\": 24,\n\t\"customer_details\": [\n\t\t{ \"key\": \"Name\", \"value\": \"Jane Doe\" },\n\t\t{ \"key\": \"Phone\", \"value\": \"+01 345 678 901\" },\n\t\t{ \"key\": \"Address\", \"value\": \"42 Main road - 95531\" }\n\t],\n\t\"items\": [\n\t\t{ \"item\": \"Item 1\", \"price\": 34.99 },\n\t\t{ \"item\": \"Item 2\", \"price\": 159.99 },\n\t\t{ \"item\": \"Item 3\", \"price\": 0.99 }\n\t]\n}\n--]]\n\n\n-----------------------------\n--- Init global variables ---\ntarget_folder = get_input(\"target_folder\")\ntoday = create_date_time()\n\nhtml = http_request(\"https://raw.githubusercontent.com/Raudius/files_scripts/master/examples/invoice.mustache\")\nif (not html or string.len(html) < 1) then\n\tabort(\"Could not fetch the invoice template.\")\nend\n\n----------------------\n--- Formats a date ---\nfunction fdate(date, fmt)\n\treturn format_date_time(date, \"en_GB\", null, fmt)\nend\n\n--------------------------------------------\n--- Formats a value as a localised price ---\nfunction fprice(v)\n\treturn format_price(v, \"€\", \"EUR\", \"en_GB\")\nend\n\n----------------------------------------------------\n--- Generates an invoice using the provided data ---\nfunction generate_invoice(data)\n\t-- Set invoice date\n\tdata.invoice_date = fdate(today, \"dd MMMM yyyy\")\n\n\t-- Total calculation\n\tlocal rows_formatted = {}\n\tlocal total_rows = 0\n\tfor k,v in pairs(data.items) do\n\t\ttotal_rows = total_rows + v.price\n\t\trows_formatted[k]= { item= v.item, price= fprice(v.price) }\n\tend\n\n\t-- VAT calculation\n\tlocal vat_percent = (data.vat_percent or 0) / 100\n\tlocal vat = total_rows * vat_percent\n\n\t-- Price formatting\n\tdata.total_rows = fprice(total_rows)\n\tdata.vat = fprice(vat)\n\tdata.total = fprice(total_rows + vat)\n\tdata.rows = rows_formatted\n\n\t-- Generate and save\n\tlocal name = fdate(today, \"yyyyMM\") .. \" Invoice \" .. data.invoice_number .. \".pdf\"\n\tlocal invoice_pdf = html_to_pdf(mustache(html, data))\n\tnew_file(target_folder, name, invoice_pdf)\nend\n\n-------------------------------------------------\n--- Generates the invoice for each input file ---\nfunction generate_invoices()\n\tfor k,v in pairs(get_input_files()) do\n\t\tlocal in_data = json(file_content(v))\n\t\tif (in_data and type(in_data) == \"table\") then\n\t\t\tgenerate_invoice(in_data)\n\t\telse\n\t\t\tabort(\"Could not read: \" .. v.name)\n\t\tend\n\tend\nend\n\n-- Run\ngenerate_invoices()\n",
+		"enabled": 0,
+		"limitGroups": [],
+		"public": 0,
+		"mimetype": "",
+		"inputs": [
+			{
+				"name": "output_location",
+				"description": "Save location",
+				"options": {
+					"type": "filepick",
+					"filepickMimes": [
+						"httpd/unix-directory"
+					]
+				}
+			}
+		]
+	}
+]

--- a/lib/Service/ScriptService.php
+++ b/lib/Service/ScriptService.php
@@ -52,9 +52,16 @@ class ScriptService {
 
 	/**
 	 * @throws \OCP\DB\Exception
+	 * @throws ScriptValidationException
 	 */
 	public function createScriptFromJson(array $scriptData): Script {
 		$script = Script::newFromJson($scriptData);
+
+		$validationErrors = $this->validate($script);
+		if (count($validationErrors) > 0) {
+			throw new ScriptValidationException($validationErrors);
+		}
+
 		$script = $this->scriptMapper->insert($script);
 
 		$inputData = $scriptData['inputs'] ?? [];

--- a/lib/Service/ScriptValidationException.php
+++ b/lib/Service/ScriptValidationException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OCA\FilesScripts\Service;
+
+class ScriptValidationException extends \Exception {
+	private array $validationErrors;
+
+	/**
+	 * @param string[] $validations
+	 */
+	public function __construct(array $validationErrors) {
+		$this->validationErrors = $validationErrors;
+		$reasons = implode(',', $validationErrors);
+		parent::__construct("Script is not valid: $reasons");
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getValidationErrors(): array {
+		return $this->validationErrors;
+	}
+}


### PR DESCRIPTION
Relates to: https://github.com/Raudius/files_scripts/issues/108

This PR adds the ability to import and export JSON-serialized scripts using occ comands.

**Usage example:**
```bash
occ files_scripts:export > scripts.json
occ files_scripts:import < scripts.json
```