### PR TITLE
Add `get_activity`function to API

### DIFF
--- a/.github/workflows/behat-sqlite.yml
+++ b/.github/workflows/behat-sqlite.yml
@@ -56,6 +56,13 @@ jobs:
           repository: nextcloud/server
           ref: ${{ matrix.server-versions }}
 
+      - name: Checkout activity app
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: nextcloud/activity
+          path: apps/activity
+          ref: ${{ matrix.server-versions }}
+
       - name: Checkout app
         uses: actions/checkout@v3
         with:
@@ -83,6 +90,7 @@ jobs:
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
           ./occ config:system:set --value="http://localhost:8080" -- overwrite.cli.url
           ./occ app:enable --force ${{ env.APP_NAME }}
+          ./occ app:enable --force activity
           for user in alice bob jane john; do \
             OC_PASS="$user" ./occ user:add --password-from-env "$user"; \
           done

--- a/lib/Interpreter/FunctionProvider.php
+++ b/lib/Interpreter/FunctionProvider.php
@@ -3,6 +3,7 @@
 namespace OCA\FilesScripts\Interpreter;
 
 use OCA\FilesScripts\Interpreter\Functions\Files\File_Delete_Unsafe;
+use OCA\FilesScripts\Interpreter\Functions\Nextcloud\Get_Activity;
 use OCA\FilesScripts\Interpreter\Functions\Output\Abort;
 use OCA\FilesScripts\Interpreter\Functions\Output\Add_Message;
 use OCA\FilesScripts\Interpreter\Functions\Output\Clear_Messages;
@@ -123,9 +124,10 @@ class FunctionProvider implements IFunctionProvider {
 		_Include $f58,
 		Shares_Find $f59,
 		Share_File $f60,
+		File_Delete_Unsafe $f61,
 		Share_Delete $f62,
 		View_Files $f63,
-		File_Delete_Unsafe $f64
+		Get_Activity $f64
 	) {
 		$this->functions = func_get_args();
 	}

--- a/lib/Interpreter/Functions/Nextcloud/EventSerializerTrait.php
+++ b/lib/Interpreter/Functions/Nextcloud/EventSerializerTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Nextcloud;
+
+use OCA\Activity\Data;
+use OCP\Activity\IEvent;
+
+/**
+ * Trait which manages Event (de)serialization..
+ */
+trait EventSerializerTrait {
+	// TODO: PHP 8.2 add trait const for TYPE="user"
+	private function serializeEvent(int $id, IEvent $event): array {
+		return [
+			"_type" => "event",
+			"id" => $id,
+			'app' => $event->getApp(),
+			'type' => $event->getType(),
+			'affecteduser' => $event->getAffectedUser(),
+			'user' => $event->getAuthor(),
+			'timestamp' => $event->getTimestamp(),
+			'subject' => $event->getParsedSubject(),
+			'message' => $event->getParsedMessage(),
+			'object_type' => $event->getObjectType(),
+			'object_id' => $event->getObjectId(),
+			'object_name' => $event->getObjectName(),
+			'link' => $event->getLink(),
+		];
+	}
+
+	private function deserializeEvent($activityData, Data $activityManager): ?IEvent {
+		if (!is_array($activityData) || ($userData["_type"] ?? null) !== "event") {
+			return null;
+		}
+
+		try {
+			$activity = $activityManager->getById($activityData["id"]);
+		} catch (\Throwable $e) {
+			return null;
+		}
+		return $activity;
+	}
+}

--- a/lib/Interpreter/Functions/Nextcloud/Get_Activity.php
+++ b/lib/Interpreter/Functions/Nextcloud/Get_Activity.php
@@ -91,7 +91,7 @@ class Get_Activity extends RegistrableFunction {
 			0,
 			200,
 			'desc',
-			'all',
+			'filter',
 			$objectType,
 			$objectId,
 			true

--- a/lib/Interpreter/Functions/Nextcloud/Get_Activity.php
+++ b/lib/Interpreter/Functions/Nextcloud/Get_Activity.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace OCA\FilesScripts\Interpreter\Functions\Nextcloud;
+
+use OCA\FilesScripts\Interpreter\RegistrableFunction;
+use OCA\Activity\Data;
+use OCA\Activity\GroupHelper;
+use OCA\Activity\UserSettings;
+use OCA\Activity\ViewInfoCache;
+use OCP\Files\IMimeTypeDetector;
+use OCP\IPreview;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+
+
+/**
+ * `get_activity(Object object, [Table filters]={}): Table`
+ *
+ * Returns a table of activity data.
+ */
+class Get_Activity extends RegistrableFunction {
+	use UserSerializerTrait;
+	private ?IUser $user;
+	private ?Data $activityData;
+	private ?GroupHelper $helper;
+	private ?UserSettings $settings;
+	private ?ViewInfoCache $infoCache;
+	private IURLGenerator $urlGenerator;
+	private IPreview $preview;
+	private IMimeTypeDetector $mimeTypeDetector;
+	private IUserManager $userManager;
+
+	public function __construct(
+		?IUser $user,
+		IUserManager $userManager,
+		?Data $data,
+		?GroupHelper $helper,
+		?UserSettings $settings,
+		?ViewInfoCache $infoCache,
+		IURLGenerator $urlGenerator,
+		IPreview $preview,
+		IMimeTypeDetector $mimeTypeDetector
+	) {
+		$this->user = $user;
+		$this->userManager = $userManager;
+		$this->activityData = $data;
+		$this->helper = $helper;
+		$this->settings = $settings;
+		$this->urlGenerator = $urlGenerator;
+		$this->preview = $preview;
+		$this->mimeTypeDetector = $mimeTypeDetector;
+		$this->infoCache = $infoCache;
+	}
+
+	public function run($object=[], $filters=[]): array {
+		if (!class_exists(\OCA\Activity\Data::class)) {
+			return [];
+		}
+
+		$user = $this->getUser($filters);
+		if (!$user) {
+			return [];
+		}
+
+		$objectType = $this->getObjectType($object);
+		if (!$objectType) {
+			return [];
+		}
+
+		$objectId = $object['id'] ?? null;
+		if (null == $objectId) {
+			return [];
+		}
+
+		$activities = $this->activityData->get(
+			$this->helper,
+			$this->settings,
+			$this->user,
+			0,
+			0,
+			'desc',
+			'all',
+			$objectType,
+			$objectId
+		);
+		return $this->reindex($activities);
+	}
+
+	private function getUser($filters): ?IUser {
+		$user = null;
+		$userData = $filters['user'] ?? null;
+		if ($userData) {
+			$user = $this->deserializeUser($userData, $this->userManager);
+		}
+
+		if (!$user) {
+			$user = $this->user;
+		}
+
+		return $user;
+	}
+
+	private function getObjectType($object) {
+		$type = $object['_type'] ?? '';
+
+		switch ($type) {
+			case 'file':
+				return 'files'; // TODO: Look for OCA constant of object types
+			default:
+				return '';
+		}
+	}
+}

--- a/lib/Interpreter/Functions/Nextcloud/Get_Activity.php
+++ b/lib/Interpreter/Functions/Nextcloud/Get_Activity.php
@@ -16,9 +16,18 @@ use OCP\IUserSession;
 
 
 /**
- * `get_activity(Object object, [Table filters]={}): Table`
+ * `get_activity(object): Event[]`
  *
- * Returns a table of activity data.
+ * Returns a table of activity data for the given object. Currently only `File` objects may be used for retrieving activity.
+ *
+ * The function returns a table of `Event` objects.
+ *
+ * Example:
+ * ```lua
+ * file = get_input_files()[1]
+ * activity = get_activity(file)
+ * add_message(json(activity))
+ * ```
  */
 class Get_Activity extends RegistrableFunction {
 	use EventSerializerTrait;
@@ -56,7 +65,7 @@ class Get_Activity extends RegistrableFunction {
 		$this->infoCache = $infoCache;
 	}
 
-	public function run($object=[], $filters=[]): array {
+	public function run($object=[]): array {
 		if (!class_exists(\OCA\Activity\Data::class)) {
 			return [];
 		}
@@ -99,14 +108,14 @@ class Get_Activity extends RegistrableFunction {
 	/**
 	 * Translates the internal object["_type"] into the Nextcloud object type.
 	 */
-	private function getObjectType($object): string {
-		$type = $object['_type'] ?? 'files_scripts-unknown_type';
+	private function getObjectType($object): ?string {
+		$type = $object['_type'] ?? '';
 
 		switch ($type) {
 			case 'file':
 				return 'files'; // TODO: Look for OCA constant of object types
 			default:
-				return $type;
+				return null;
 		}
 	}
 }

--- a/tests/integration/features/fixtures/test_base.lua
+++ b/tests/integration/features/fixtures/test_base.lua
@@ -56,3 +56,25 @@ function assertSameNode(node1, node2, message)
 
   assertTrue(success, message)
 end
+
+function assertEqualTable(o1, o2, message)
+	if o1 == o2 then return end
+	local o1Type = type(o1)
+	local o2Type = type(o2)
+
+	assertEquals(o1Type, o2Type, message)
+	assertEquals(o1Type, "table", message)
+
+	local keySet = {}
+	for key1, value1 in pairs(o1) do
+		local value2 = o2[key1]
+		assertNotNil(value2, message)
+		assertEqualTable(value1, value2, message)
+		keySet[key1] = true
+	end
+
+	for key2, _ in pairs(o2) do
+		assertTrue(keySet[key2], message)
+	end
+	return true
+end

--- a/tests/integration/features/fixtures/test_nextcloud.lua
+++ b/tests/integration/features/fixtures/test_nextcloud.lua
@@ -137,3 +137,32 @@ found_shares = shares_find(sample_file)
 assertNotEmpty(found_shares, "no shares found after share creation")
 found_share = found_shares[1]
 assertEquals(json(found_share), json(share), "created-share and found-share not equal (link share)")
+
+
+
+--
+-- Test get_activity
+--
+
+local file = new_file(home(), "activity_foo.txt")
+local activity = get_activity(file)
+
+assertEquals(#activity, 1, "Newly created file should have one activity event (creation)")
+
+created_event = activity[1]
+assertEquals(created_event["_type"], "event", "get_activity() should always return event objects")
+assertEquals(created_event["type"], "file_created", "Newly created file should have the `file_created` event")
+
+
+file = file_move(file, nil, "activity_bar.txt")
+activity = get_activity(file)
+
+assertEquals(#activity, 2, "After moving the file it should have 2 events (creation, modification)")
+assertEquals(activity[1]["_type"], "event")
+assertEquals(activity[2]["_type"], "event")
+
+-- First event should be "latest", file changed
+assertEquals(activity[1]["type"], "file_changed", "After moving a file, its first event should be `file_changed`")
+
+-- Second event should be the same as the previous created event
+assertEqualTable(activity[2], created_event, "Moved file should still have the creation event")


### PR DESCRIPTION
Solves: https://github.com/Raudius/files_scripts/issues/109

This PR adds the ability to fetch activity data from Nextcloud objects via the `get_activity` function.

Currently it is only possible to get activity events from File objects. If/when calendar/task integration is implemented, activity data could also be fetched from `Task` and `CalendarEvent` objects.