### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
+## 3.1.0
+
+### Announcement
+This is the last feature release for Nextcloud 27. Future releases will only support Nextcloud 28+. 
+
+This is due to significant changes to the Files app, which would complicate maintaining backwards-compatible integration.
+
+### Added
+- Adds parameter to `file_delete` which allows bypassing trash-bin.
+- Adds `get_activity` function to get an array of the activity events for a file.
+- Adds `file_delete_unsafe` for deleting files from other users.
+- Adds ability to export script collections via `occ files_scripts:export`.
+- Adds ability to import script collections via `occ files_scripts:import`.
+
+### Fixed
+- Fixed `file_move_unsafe` function on Nextcloud 27.
+- Fixed missing database default value on script input `options` column.
+
 ## 3.0.0
 
-## Added
+### Added
 - ⚠️ Deprecated functions removed from Scripting API!
 - Nextcloud 27 support
 - Added `view_files` function
@@ -14,17 +32,17 @@
 - New selection component for setting filepick mimetypes and multiselect options
 - Expanded some script input types with additional options
 
-## Fixed
+### Fixed
 - Documentation link in settings now points to installed version docs (not master docs)
 - Fixed checkbox input behaviour
 - Removed deprecated function usages from example scripts
 
-## Deprecated
+### Deprecated
 - Deprecated `html_to_pdf` function
 
 ## 2.2.1
 
-## Changed
+### Changed
 - Fixed some issues with new NcSelect component
 
 ## 2.2.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Allows administrators to write small scripts which users can run through via the
 ⚠️**Attention** Scripts may modify and delete files permanently. Take care and make sure to read the documentation thoroughly before scripting.
 	]]></description>
 
-    <version>3.0.0</version>
+    <version>3.1.0</version>
 
 	<licence>agpl</licence>
 	<author mail="r.ferreira.fuentes@gmail.com" >Raul Ferreira Fuentes</author>

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -6,6 +6,7 @@
     - [file_copy](#file_copy)  
     - [file_copy_unsafe](#file_copy_unsafe)  
     - [file_delete](#file_delete)  
+    - [file_delete_unsafe](#file_delete_unsafe)  
     - [file_move](#file_move)  
     - [file_move_unsafe](#file_move_unsafe)  
     - [file_unlock](#file_unlock)  
@@ -30,6 +31,7 @@
     - [comment_create](#comment_create)  
     - [comment_delete](#comment_delete)  
     - [comments_find](#comments_find)  
+    - [get_activity](#get_activity)  
     - [get_file_tags](#get_file_tags)  
     - [notify](#notify)  
     - [share_delete](#share_delete)  
@@ -125,12 +127,22 @@ file_copy_unsafe(file, "alice/files/inbox", "message.txt")
 ```
 ### file_delete
 
-`file_delete(Node node, [Bool success_if_not_found]=true): Bool`  
+`file_delete(Node node, [Bool success_if_not_found]=true, [Bool bypass_trahsbin]=true): Bool`  
   
 Deletes the specified file/folder node.  
 Returns whether deletion succeeded.  
   
-By default, the function also returns true if the file was not found. This behaviour can be changed by setting its second argument to `false`.
+By default, the function also returns true if the file was not found. This behaviour can be changed by setting its second argument to `false`.  
+  
+The third argument `bypass_trashbin` may be used to delete the file permanently, if set to true.
+### file_delete_unsafe
+
+`file_delete_unsafe(String path, [Bool success_if_not_found]=true): Bool`  
+  
+Deletes a file/folder node in the given path.  
+By default, the function also returns true if the file was not found. This behaviour can be changed by setting its second argument to `false`.  
+  
+⚠️ Use of this function is strongly discouraged as it may allow users to delete files from other users.
 ### file_move
 
 `file_move(Node file, [String folder = nil], [String new_name = nil]): Node|null`  
@@ -329,6 +341,20 @@ tags({file= get_input_files()[1]}) -- Finds comments for a file
 tags({id= 21})                     -- Finds comment with ID 21  
 tags({parent_id= 13})              -- Finds comments tree of comment 13  
 tags({id= 21, parent_id= 13})      -- Finds comment with ID 21 or (if comment 21 does not exist) the comment tree of comment 13  
+```
+### get_activity
+
+`get_activity(object): Event[]`  
+  
+Returns a table of activity data for the given object. Currently only `File` objects may be used for retrieving activity.  
+  
+The function returns a table of `Event` objects.  
+  
+Example:  
+```lua  
+file = get_input_files()[1]  
+activity = get_activity(file)  
+add_message(json(activity))  
 ```
 ### get_file_tags
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "files_scripts",
 	"description": "Nextcloud app for running custom scripts on files.",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"author": "Raul Ferreira Fuentes <r.ferreira.fuentes@gmail.com>",
 	"homepage": "https://github.com/",
 	"license": "agpl",


### PR DESCRIPTION
### Announcement
This is the last feature release for Nextcloud 27. Future releases will only support Nextcloud 28+. 

This is due to significant changes to the Files app, which would complicate maintaining backwards-compatible integration.

### Added
- Adds parameter to `file_delete` which allows bypassing trash-bin.
- Adds `get_activity` function to get an array of the activity events for a file.
- Adds `file_delete_unsafe` for deleting files from other users.
- Adds ability to export script collections via `occ files_scripts:export`.
- Adds ability to import script collections via `occ files_scripts:import`.

### Fixed
- Fixed `file_move_unsafe` function on Nextcloud 27.
- Fixed missing database default value on script input `options` column.