### PR TITLE
Restrict file action by file types (mime or extension)

### DIFF
--- a/lib/Controller/ScriptController.php
+++ b/lib/Controller/ScriptController.php
@@ -85,7 +85,7 @@ class ScriptController extends Controller {
 		bool $enabled,
 		array $limitGroups,
 		bool $public,
-		array $mimetypes
+		array $fileTypes
 	): Response {
 		$script = new Script();
 		$script->setTitle($title);
@@ -94,7 +94,7 @@ class ScriptController extends Controller {
 		$script->setEnabled($enabled);
 		$script->setLimitGroupsArray($limitGroups);
 		$script->setPublic($public);
-		$script->setMimetypesArray($mimetypes);
+		$script->setFileTypesArray($fileTypes);
 
 		$errors = $this->scriptService->validate($script);
 		if ($errors) {
@@ -122,7 +122,7 @@ class ScriptController extends Controller {
 		bool $enabled,
 		array $limitGroups,
 		bool $public,
-		array $mimetypes
+		array $fileTypes
 	): Response {
 		$script = $this->scriptMapper->find($id);
 		if (!$script) {
@@ -135,7 +135,7 @@ class ScriptController extends Controller {
 		$script->setEnabled($enabled);
 		$script->setLimitGroupsArray($limitGroups);
 		$script->setPublic($public);
-		$script->setMimetypesArray($mimetypes);
+		$script->setFileTypesArray($fileTypes);
 
 		$errors = $this->scriptService->validate($script);
 		if ($errors) {

--- a/lib/Controller/ScriptController.php
+++ b/lib/Controller/ScriptController.php
@@ -85,7 +85,7 @@ class ScriptController extends Controller {
 		bool $enabled,
 		array $limitGroups,
 		bool $public,
-		?string $mimetype
+		array $mimetypes
 	): Response {
 		$script = new Script();
 		$script->setTitle($title);
@@ -94,7 +94,7 @@ class ScriptController extends Controller {
 		$script->setEnabled($enabled);
 		$script->setLimitGroupsArray($limitGroups);
 		$script->setPublic($public);
-		$script->setMimetype($mimetype ?? "");
+		$script->setMimetypesArray($mimetypes);
 
 		$errors = $this->scriptService->validate($script);
 		if ($errors) {
@@ -122,7 +122,7 @@ class ScriptController extends Controller {
 		bool $enabled,
 		array $limitGroups,
 		bool $public,
-		?string $mimetype
+		array $mimetypes
 	): Response {
 		$script = $this->scriptMapper->find($id);
 		if (!$script) {
@@ -135,7 +135,7 @@ class ScriptController extends Controller {
 		$script->setEnabled($enabled);
 		$script->setLimitGroupsArray($limitGroups);
 		$script->setPublic($public);
-		$script->setMimetype($mimetype ?? "");
+		$script->setMimetypesArray($mimetypes);
 
 		$errors = $this->scriptService->validate($script);
 		if ($errors) {

--- a/lib/Db/Script.php
+++ b/lib/Db/Script.php
@@ -20,6 +20,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int getPublic()
  * @method setMimetype(string $mimetypes)
  * @method string getMimetype()
+ * @method setMimetypes(?string $mimetypes)
+ * @method string getMimetypes()
  */
 class Script extends Entity implements JsonSerializable {
 	protected ?string $title = null;
@@ -28,7 +30,8 @@ class Script extends Entity implements JsonSerializable {
 	protected ?int $enabled = null;
 	protected ?string $limitGroups = null;
 	protected ?int $public = null;
-	protected ?string $mimetype = null;
+	protected ?string $mimetypes = null;
+	protected ?string $mimetype = null; // TODO remove mimetype property and drop column from db
 
 	public function setLimitGroupsArray(array $groupsArray): void {
 		$groups = implode(",", $groupsArray) ?: '';
@@ -37,6 +40,17 @@ class Script extends Entity implements JsonSerializable {
 
 	public function getLimitGroupsArray(): array {
 		return array_filter(explode(",", $this->limitGroups) ?: []);
+	}
+	public function setMimetypesArray(array $mimetypesArray): void {
+		$mimetypes = implode(",", $mimetypesArray) ?: '';
+		$this->setMimetypes($mimetypes);
+	}
+
+	public function getMimetypesArray(): array {
+		if (!$this->mimetypes) {
+			return [];
+		}
+		return array_filter(explode(",", $this->mimetypes) ?: []);
 	}
 
 	public static function newFromJson(array $jsonData): Script {
@@ -69,7 +83,7 @@ class Script extends Entity implements JsonSerializable {
 			'enabled' => $this->enabled,
 			'limitGroups' => $this->getLimitGroupsArray(),
 			'public' => $this->public,
-			'mimetype' => $this->mimetype
+			'mimetypes' => $this->getMimetypesArray()
 		];
 	}
 }

--- a/lib/Db/Script.php
+++ b/lib/Db/Script.php
@@ -20,8 +20,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int getPublic()
  * @method setMimetype(string $mimetypes)
  * @method string getMimetype()
- * @method setMimetypes(?string $mimetypes)
- * @method string getMimetypes()
+ * @method setFileTypes(?string $fileTypes)
+ * @method string getFileTypes()
  */
 class Script extends Entity implements JsonSerializable {
 	protected ?string $title = null;
@@ -30,7 +30,7 @@ class Script extends Entity implements JsonSerializable {
 	protected ?int $enabled = null;
 	protected ?string $limitGroups = null;
 	protected ?int $public = null;
-	protected ?string $mimetypes = null;
+	protected ?string $fileTypes = null;
 	protected ?string $mimetype = null; // TODO remove mimetype property and drop column from db
 
 	public function setLimitGroupsArray(array $groupsArray): void {
@@ -41,16 +41,16 @@ class Script extends Entity implements JsonSerializable {
 	public function getLimitGroupsArray(): array {
 		return array_filter(explode(",", $this->limitGroups) ?: []);
 	}
-	public function setMimetypesArray(array $mimetypesArray): void {
+	public function setFileTypesArray(array $mimetypesArray): void {
 		$mimetypes = implode(",", $mimetypesArray) ?: '';
-		$this->setMimetypes($mimetypes);
+		$this->setFileTypes($mimetypes);
 	}
 
-	public function getMimetypesArray(): array {
-		if (!$this->mimetypes) {
+	public function getFileTypesArray(): array {
+		if (!$this->fileTypes) {
 			return [];
 		}
-		return array_filter(explode(",", $this->mimetypes) ?: []);
+		return array_filter(explode(",", $this->fileTypes) ?: []);
 	}
 
 	public static function newFromJson(array $jsonData): Script {
@@ -58,7 +58,10 @@ class Script extends Entity implements JsonSerializable {
 		$script->setTitle($jsonData["title"] ?? "");
 		$script->setDescription($jsonData["description"] ?? "");
 		$script->setProgram($jsonData["program"] ?? "");
-		$script->setMimetype($jsonData["mimetype"] ?? "");
+
+		// For backwards compatibility we allow the old `mimetype` type
+		$fileTypes = $jsonData["fileTypes"] ?? [$jsonData["mimetype"]] ?: [];
+		$script->setFileTypesArray($fileTypes);
 
 		$enabled = $jsonData["enabled"] ?? 0;
 		$enabled = is_integer($enabled) ? $enabled : 0;
@@ -83,7 +86,7 @@ class Script extends Entity implements JsonSerializable {
 			'enabled' => $this->enabled,
 			'limitGroups' => $this->getLimitGroupsArray(),
 			'public' => $this->public,
-			'mimetypes' => $this->getMimetypesArray()
+			'fileTypes' => $this->getFileTypesArray()
 		];
 	}
 }

--- a/lib/Middleware/examples.json
+++ b/lib/Middleware/examples.json
@@ -6,7 +6,7 @@
 		"enabled": 0,
 		"limitGroups": [],
 		"public": 0,
-		"mimetype": "",
+		"fileTypes": [],
 		"inputs": [
 			{
 				"name": "company_name",
@@ -54,7 +54,7 @@
 		"enabled": 0,
 		"limitGroups": [],
 		"public": 0,
-		"mimetype": "application/pdf",
+		"fileTypes": ["application/pdf"],
 		"inputs": [
 			{
 				"name": "file_name",
@@ -80,7 +80,7 @@
 		"enabled": 0,
 		"limitGroups": [],
 		"public": 0,
-		"mimetype": "",
+		"fileTypes": [],
 		"inputs": []
 	},
 	{
@@ -90,7 +90,7 @@
 		"enabled": 0,
 		"limitGroups": [],
 		"public": 0,
-		"mimetype": "",
+		"fileTypes": [],
 		"inputs": [
 			{
 				"name": "output_location",

--- a/lib/Migration/Version031000Date20231211.php
+++ b/lib/Migration/Version031000Date20231211.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace OCA\FilesScripts\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+use Psr\Log\LoggerInterface;
+
+class Version031000Date20231211 extends SimpleMigrationStep {
+	private LoggerInterface $logger;
+	private IDBConnection $connection;
+
+	public function __construct(LoggerInterface $logger, IDBConnection $connection) {
+		$this->logger = $logger;
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('filescripts')) {
+			$table = $schema->getTable('filescripts');
+
+			$table->addColumn('mimetypes', 'string', [
+				'notnull' => false,
+				'length' => 128 * 30
+			]);
+		} else {
+			$this->logger->error('File scripts (Version031000Date20231211) migration failed, because `filescripts` table does not exist.');
+		}
+		return $schema;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('filescripts')) {
+			$this->logger->error('File scripts (Version030000Date20230324) migration postschemachange step failed, because `filescripts` table does not exist.');
+			return null;
+		}
+		/** @var \Doctrine\DBAL\Schema\Table $table */
+		$table = $schema->getTable('filescripts');
+		if (!$table->hasColumn('mimetypes')) {
+			$this->logger->error('File scripts (Version030000Date20230324) migration postschemachange step failed, because `filescripts.mimetypes` column does not exist.');
+			return null;
+		}
+
+		try {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->update('filescripts')
+				->set('mimetypes', 'mimetype');
+			$qb->executeStatement();
+
+
+			$qb = $this->connection->getQueryBuilder();
+			$eb = $this->connection->getQueryBuilder()->expr();
+
+			$qb->update('filescripts')
+				->where($eb->eq('mimetypes', $eb->literal("")))
+				->set('mimetypes', 'null');
+			$qb->executeStatement();
+		} catch (SchemaException $e) {
+			throw $e;
+		} catch (\Throwable $e) {
+			$this->logger->error('File scripts (Version030000Date20230324) migration postschemachange step failed with exception: ' . $e->getMessage() . ' Trace: ' . $e->getTraceAsString());
+			return null;
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version031000Date20231211.php
+++ b/lib/Migration/Version031000Date20231211.php
@@ -33,7 +33,7 @@ class Version031000Date20231211 extends SimpleMigrationStep {
 		if ($schema->hasTable('filescripts')) {
 			$table = $schema->getTable('filescripts');
 
-			$table->addColumn('mimetypes', 'string', [
+			$table->addColumn('file_types', 'string', [
 				'notnull' => false,
 				'length' => 128 * 30
 			]);
@@ -52,15 +52,15 @@ class Version031000Date20231211 extends SimpleMigrationStep {
 		}
 		/** @var \Doctrine\DBAL\Schema\Table $table */
 		$table = $schema->getTable('filescripts');
-		if (!$table->hasColumn('mimetypes')) {
-			$this->logger->error('File scripts (Version030000Date20230324) migration postschemachange step failed, because `filescripts.mimetypes` column does not exist.');
+		if (!$table->hasColumn('file_types')) {
+			$this->logger->error('File scripts (Version030000Date20230324) migration postschemachange step failed, because `filescripts.file_types` column does not exist.');
 			return null;
 		}
 
 		try {
 			$qb = $this->connection->getQueryBuilder();
 			$qb->update('filescripts')
-				->set('mimetypes', 'mimetype');
+				->set('file_types', 'mimetype');
 			$qb->executeStatement();
 
 
@@ -68,8 +68,8 @@ class Version031000Date20231211 extends SimpleMigrationStep {
 			$eb = $this->connection->getQueryBuilder()->expr();
 
 			$qb->update('filescripts')
-				->where($eb->eq('mimetypes', $eb->literal("")))
-				->set('mimetypes', 'null');
+				->where($eb->eq('file_types', $eb->literal("")))
+				->set('file_types', 'null');
 			$qb->executeStatement();
 		} catch (SchemaException $e) {
 			throw $e;

--- a/src/components/ScriptEdit.vue
+++ b/src/components/ScriptEdit.vue
@@ -48,7 +48,7 @@
 					{{ t('files_scripts', 'Limit to specific MIME type') }}
 				</NcCheckboxRadioSwitch>
 				<FreeSelect v-if="limitMimesEnabled"
-			 		v-model="mimetypes"
+			 		v-model="fileTypes"
 				 	:label="t('files_scripts', 'MIME type (e.g. text/plain)')"
 				/>
 
@@ -167,14 +167,12 @@ export default {
 				this.$store.commit('updateCurrentScript', { limitGroups: value })
 			},
 		},
-		mimetypes: {
+		fileTypes: {
 			get() {
-				console.log("Get mimetypes")
-				return this.script ? this.script.mimetypes : ""
+				return this.script ? this.script.fileTypes : ""
 			},
 			set(value) {
-				console.log("Set mimetypes", value)
-				this.$store.commit('updateCurrentScript', { mimetypes: value })
+				this.$store.commit('updateCurrentScript', { fileTypes: value })
 			},
 		}
 	},
@@ -207,7 +205,7 @@ export default {
 		t,
 		remounted() {
 			this.limitGroupsEnabled = this.limitGroups.length > 0
-			this.limitMimesEnabled = this.mimetypes.length > 0
+			this.limitMimesEnabled = this.fileTypes.length > 0
 		},
 		doSaveKeyboardShortcut(e) {
 			const ctrlS = (e.keyCode === 83 && e.ctrlKey)

--- a/src/components/ScriptEdit.vue
+++ b/src/components/ScriptEdit.vue
@@ -45,11 +45,11 @@
 				/>
 
 				<NcCheckboxRadioSwitch type="switch" :checked.sync="limitMimesEnabled" @update:checked="toggleLimitMimes">
-					{{ t('files_scripts', 'Limit to specific MIME type') }}
+					{{ t('files_scripts', 'Limit by file types') }}
 				</NcCheckboxRadioSwitch>
 				<FreeSelect v-if="limitMimesEnabled"
 			 		v-model="fileTypes"
-				 	:label="t('files_scripts', 'MIME type (e.g. text/plain)')"
+				 	:label="t('files_scripts', 'Media type or file extension  (e.g. text/plain, doc)')"
 				/>
 
 				<EditInputs :script-id="script.id" @changed="updateInputs" />

--- a/src/components/ScriptEdit.vue
+++ b/src/components/ScriptEdit.vue
@@ -47,12 +47,9 @@
 				<NcCheckboxRadioSwitch type="switch" :checked.sync="limitMimesEnabled" @update:checked="toggleLimitMimes">
 					{{ t('files_scripts', 'Limit to specific MIME type') }}
 				</NcCheckboxRadioSwitch>
-				<NcTextField v-if="limitMimesEnabled"
-			 		:value.sync="mimetype"
+				<FreeSelect v-if="limitMimesEnabled"
+			 		v-model="mimetypes"
 				 	:label="t('files_scripts', 'MIME type (e.g. text/plain)')"
-				 	trailing-button-icon="close"
-				 	:show-trailing-button="!!mimetype"
-					@trailing-button-click="mimetype = ''"
 				/>
 
 				<EditInputs :script-id="script.id" @changed="updateInputs" />
@@ -170,12 +167,14 @@ export default {
 				this.$store.commit('updateCurrentScript', { limitGroups: value })
 			},
 		},
-		mimetype: {
+		mimetypes: {
 			get() {
-				return this.script ? this.script.mimetype : ""
+				console.log("Get mimetypes")
+				return this.script ? this.script.mimetypes : ""
 			},
 			set(value) {
-				this.$store.commit('updateCurrentScript', { mimetype: value })
+				console.log("Set mimetypes", value)
+				this.$store.commit('updateCurrentScript', { mimetypes: value })
 			},
 		}
 	},
@@ -208,7 +207,7 @@ export default {
 		t,
 		remounted() {
 			this.limitGroupsEnabled = this.limitGroups.length > 0
-			this.limitMimesEnabled = !!this.mimetype
+			this.limitMimesEnabled = this.mimetypes.length > 0
 		},
 		doSaveKeyboardShortcut(e) {
 			const ctrlS = (e.keyCode === 83 && e.ctrlKey)

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,6 +1,6 @@
 import { translate as t } from './l10n'
 import {FileAction, Node, FileType, DefaultType, registerFileAction} from '@nextcloud/files'
-import {Script} from "./types/script";
+import {Script, scriptAllowedForNodes} from "./types/script";
 import FileCog from '@mdi/svg/svg/file-cog.svg';
 
 
@@ -34,28 +34,18 @@ export type HandlerFunc = (files: Node[]) => void;
 
 function buildActionObject(myHandler: HandlerFunc, script: Script|null = null): FileAction {
 	const displayName = script ? script.title : t('files_scripts', 'More actions')
-	let name = 'files_scripts_action'
-	let mime = 'all'
-	if (script) {
-		name += script.id
-		mime = script.mimetype ? script.mimetype : 'all'
-	}
+	const id = 'files_scripts_action' + (script ? script.id : "")
+	const order = 1000 + (script ? 0 : 1)
 
 	return {
-		id: name,
+		id: id,
 		displayName: (files, view): string => displayName,
 		title: (files, view): string => displayName,
 		iconSvgInline: (files, view): string => FileCog,
 		enabled: (files, view) => {
-			if (mime === "all") {
-				return true
-			}
-
-			return files.some(f => {
-				return f.mime === mime
-			})
+			return script === null || scriptAllowedForNodes(script, files)
 		},
-		order: 1001,
+		order: order,
 		exec(file, view, dir) {
 			return new Promise<null>((resolve) => {
 				myHandler([file])

--- a/src/store/scripts.ts
+++ b/src/store/scripts.ts
@@ -55,7 +55,7 @@ const mutations = {
 			description: newValues.description ?? state.selectedScript.description,
 			enabled: newValues.enabled ?? state.selectedScript.enabled,
 			limitGroups: newValues.limitGroups ?? state.selectedScript.limitGroups,
-			mimetypes: newValues.mimetypes ?? state.selectedScript.mimetypes
+			fileTypes: newValues.fileTypes ?? state.selectedScript.fileTypes
 		}
 	},
 }

--- a/src/store/scripts.ts
+++ b/src/store/scripts.ts
@@ -55,7 +55,7 @@ const mutations = {
 			description: newValues.description ?? state.selectedScript.description,
 			enabled: newValues.enabled ?? state.selectedScript.enabled,
 			limitGroups: newValues.limitGroups ?? state.selectedScript.limitGroups,
-			mimetype: newValues.mimetype ?? state.selectedScript.mimetype
+			mimetypes: newValues.mimetypes ?? state.selectedScript.mimetypes
 		}
 	},
 }

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -6,7 +6,8 @@ export interface Script {
 	enabled: boolean
 	limitGroups: string[]
 	public: boolean
-	mimetype: string
+	mimetype: string // mimetype Deprecated remove in future release
+	mimetypes: string[]
 }
 
 export interface ScriptInput {
@@ -38,7 +39,8 @@ export function defaultScript(): Script {
 		program: '',
 		public: false,
 		limitGroups: [],
-		mimetype: ''
+		mimetype: '',
+		mimetypes: [],
 	}
 }
 

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -89,7 +89,7 @@ export function scriptAllowedForNodes(script: Script, nodes: Node[]): boolean {
 			return true;
 		}
 
-		const extension = "." + node.basename.split(".").pop()
-		return scriptMimes.has(extension)
+		const extension = node.basename.split(".").pop()
+		return scriptMimes.has(extension) || scriptMimes.has("." + extension)
 	})
 }

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -1,3 +1,5 @@
+import { Node } from "@nextcloud/files"
+
 export interface Script {
 	id: number
 	title: string
@@ -74,4 +76,20 @@ export function defaultScriptInputOptions(): ScriptInputOptions {
 		allowMultiple: false,
 		textarea: false,
 	}
+}
+
+export function scriptAllowedForNodes(script: Script, nodes: Node[]): boolean {
+	if (script.fileTypes.length === 0) {
+		return true
+	}
+
+	const scriptMimes = new Set(script.fileTypes)
+	return nodes.every((node) => {
+		if (scriptMimes.has(node.mime)) {
+			return true;
+		}
+
+		const extension = "." + node.basename.split(".").pop()
+		return scriptMimes.has(extension)
+	})
 }

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -7,7 +7,7 @@ export interface Script {
 	limitGroups: string[]
 	public: boolean
 	mimetype: string // mimetype Deprecated remove in future release
-	mimetypes: string[]
+	fileTypes: string[]
 }
 
 export interface ScriptInput {
@@ -40,7 +40,7 @@ export function defaultScript(): Script {
 		public: false,
 		limitGroups: [],
 		mimetype: '',
-		mimetypes: [],
+		fileTypes: [],
 	}
 }
 

--- a/src/views/ScriptSelect.vue
+++ b/src/views/ScriptSelect.vue
@@ -59,6 +59,7 @@ import {registerMenuOption, reloadCurrentDirectory} from '../files'
 import ScriptInputComponent from '../components/ScriptSelect/ScriptInputComponent.vue'
 import {MessageType, showMessage} from "../types/Messages";
 import {Node} from "@nextcloud/files";
+import {scriptAllowedForNodes} from "../types/script";
 
 export default {
 	name: 'ScriptSelect',
@@ -91,7 +92,7 @@ export default {
 			return mimetypes.length === 1 ? mimetypes[0] : null
 		},
 		scripts() {
-			return this.allScripts.filter(s => !s.mimetype || s.mimetype === this.filterMimetype)
+			return this.allScripts.filter(s => scriptAllowedForNodes(s, this.selectedFiles))
 		},
 		allScripts() {
 			return this.$store.getters.getEnabledScripts
@@ -193,6 +194,7 @@ export default {
 				return // No enabled scripts: no need to attach the options
 			}
 
+			// Attach context menu options if enabled
 			const actionsInMenu = loadState('files_scripts', 'actions_in_menu', false);
 			if (actionsInMenu) {
 				this.allScripts.forEach((script) => {
@@ -200,9 +202,9 @@ export default {
 					registerMenuOption(selectFileFunc, script)
 				});
 			}
-			else {
-				registerMenuOption(this.selectFiles)
-			}
+
+			// Attach "More actions..." menu options
+			registerMenuOption(this.selectFiles)
 		},
 	},
 }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -442,7 +442,7 @@ class FeatureContext implements Context {
 			"enabled" => true,
 			"public" => false,
 			"limitGroups" => [],
-			"mimetype" => "",
+			"fileTypes" => [],
 		];
 	}
 


### PR DESCRIPTION
Addresses: https://github.com/Raudius/files_scripts/issues/113

This PR allows restricting file actions by file types, this replaces the old mimetype limitation.

You can now select multiple MIME-types and extensions as seen below:

![image](https://github.com/Raudius/files_scripts/assets/3178979/3c2b2cc9-38aa-441a-852a-118d20c38b42)
