### PR TITLE
Fix `tag_file` with folder input

### DIFF
--- a/lib/Event/RegisterScriptFunctionsEvent.php
+++ b/lib/Event/RegisterScriptFunctionsEvent.php
@@ -19,6 +19,10 @@ class RegisterScriptFunctionsEvent extends Event implements IFunctionProvider {
 
 	public function getFunctions(): iterable {
 		foreach ($this->functionProviders as $functionProvider) {
+			if (false === $functionProvider->isRegistrable()) {
+				continue;
+			}
+
 			foreach ($functionProvider->getFunctions() as $function) {
 				yield $function;
 			}

--- a/lib/Interpreter/Functions/Nextcloud/Tag_File.php
+++ b/lib/Interpreter/Functions/Nextcloud/Tag_File.php
@@ -32,7 +32,7 @@ class Tag_File extends RegistrableFunction {
 	}
 
 	public function run($file = [], $tagData = []): bool {
-		$fileNode = $this->getFile($this->getPath($file));
+		$fileNode = $this->getNode($this->getPath($file));
 		$tag = $this->deserializeTag($tagData, $this->tagManager);
 		if (!$fileNode || !$tag) {
 			return false;

--- a/lib/Interpreter/Functions/Nextcloud/TagsSerializerTrait.php
+++ b/lib/Interpreter/Functions/Nextcloud/TagsSerializerTrait.php
@@ -3,7 +3,7 @@
 namespace OCA\FilesScripts\Interpreter\Functions\Nextcloud;
 
 use OCP\SystemTag\ISystemTag as Tag;
-use OC\SystemTag\SystemTagManager;
+use OCP\SystemTag\ISystemTagManager;
 
 /**
  * Trait which manages Tag (de)serialization..
@@ -20,7 +20,7 @@ trait TagsSerializerTrait {
 		];
 	}
 
-	private function deserializeTag(array $tagData, SystemTagManager $tagManager): ?Tag {
+	private function deserializeTag(array $tagData, ISystemTagManager $tagManager): ?Tag {
 		if (!is_array($tagData) || ($tagData["_type"] ?? null) !== "tag") {
 			return null;
 		}

--- a/tests/integration/features/fixtures/test_nextcloud.lua
+++ b/tests/integration/features/fixtures/test_nextcloud.lua
@@ -48,6 +48,17 @@ tag_file(sample_file, test_tag)
 file_tags = get_file_tags(sample_file)
 assertNotEmpty(file_tags)
 
+-- Test folder tagging
+folder_to_tag = new_folder(home(), "folder_to_tag")
+
+file_tags = get_file_tags(folder_to_tag)
+assertEmpty(file_tags)
+
+tag_file(folder_to_tag, test_tag)
+
+file_tags = get_file_tags(folder_to_tag)
+assertNotEmpty(file_tags)
+
 
 -- Test file untagging
 unassign_success = tag_file_unassign(sample_file, test_tag)


### PR DESCRIPTION
Fixes: https://github.com/Raudius/files_scripts/issues/134

This PR introduces the following changes:

- Allow `tag_file` to tag folder nodes as intended
- Small fix wrt function registration