### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 4.0.0
+
+### Removed
+- Removes deprecated function `html_to_pdf`, it may be installed separately by installing [files_scripts_deprecated](https://github.com/Raudius/files_scripts_deprecated).
+
+### Added
+- Integrates with new files API.
+- Replaces single MIME-type restriction with multi-option file-type filtering, which works with extensions and MIME types.
+- Replaces app-wide "show actions in menu" settings option, with per-script selection.
+
 ## 3.1.3
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Allows administrators to write small scripts which users can run through via the
 ⚠️**Attention** Scripts may modify and delete files permanently. Take care and make sure to read the documentation thoroughly before scripting.
 	]]></description>
 
-    <version>3.1.3</version>
+    <version>4.0.0</version>
 
 	<licence>agpl</licence>
 	<author mail="r.ferreira.fuentes@gmail.com" >Raul Ferreira Fuentes</author>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "files_scripts",
 	"description": "Nextcloud app for running custom scripts on files.",
-	"version": "3.1.3",
+	"version": "4.0.0",
 	"author": "Raul Ferreira Fuentes <r.ferreira.fuentes@gmail.com>",
 	"homepage": "https://github.com/",
 	"license": "agpl",


### PR DESCRIPTION

### Removed
- Removes deprecated function `html_to_pdf`, it may be installed separately by installing [files_scripts_deprecated](https://github.com/Raudius/files_scripts_deprecated).

### Added
- Integrates with new files API.
- Replaces single MIME-type restriction with multi-option file-type filtering, which works with extensions and MIME types.
- Replaces app-wide "show actions in menu" settings option, with per-script selection.
