### PR TITLE
Fix Incorrect Assignment in Shares_Find Function

### DIFF
--- a/lib/Interpreter/Functions/Nextcloud/ShareSerializerTrait.php
+++ b/lib/Interpreter/Functions/Nextcloud/ShareSerializerTrait.php
@@ -20,7 +20,7 @@ trait ShareSerializerTrait {
 			'type' => $share->getShareType(),
 			'share_owner' => $share->getShareOwner(),
 			'shared_by' => $share->getSharedBy(),
-			'shared_with' => $share->getSharedBy(),
+			'shared_with' => $share->getSharedWith(),
 			'permissions' => $share->getPermissions(),
 			'token' => $share->getToken(),
 		];


### PR DESCRIPTION
Issue:
The shares_find function in the Shares_Find class incorrectly assigns the shared_by value to the shared_with field. This error results in the function returning the user who created the share (shared_by) instead of the intended recipient (shared_with).

Fix:
This fix corrects the assignment within the serializeShare method of the Shares_Find class. The line 'shared_with' => $share->getSharedBy(), has been updated to 'shared_with' => $share->getSharedWith(),. This change ensures that the shared_with field accurately reflects the user with whom the file or folder is shared, aligning with the intended functionality of the method.

Impact:
This fix is crucial for any functionality relying on accurately determining the recipient of a shared resource. It ensures that scripts or features using this function will receive correct information regarding share recipients, which is essential for proper access control, auditing, and user-specific operations in Nextcloud.

Additional Notes:
The fix is minor but significantly impacts the functionality of the shares_find method. No other parts of the code are affected by this change. The fix has been tested to ensure it resolves the issue without introducing any new bugs or regressions.