### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.1.0
+
+### Added
+- Nextcloud 29 support
+- Option to add inputs to occ actions (@ZeiTee)
+- Button to duplicate a file action
+
+### Fixed
+- Retrieval of nodes inside group-folders for flow actions (@ZeiTee)
+- Prevent creation of deleted nodes during flow action setup
+
 ## 4.0.3
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Allows administrators to write small scripts which users can run through the fil
 ⚠️ **Attention** Scripts may modify and delete files permanently. Take care and make sure to read the documentation thoroughly before scripting.
 	]]></description>
 
-    <version>4.0.3</version>
+    <version>4.1.0</version>
 
 	<licence>agpl</licence>
 	<author mail="r.ferreira.fuentes@gmail.com" >Raul Ferreira Fuentes</author>
@@ -35,7 +35,7 @@ Allows administrators to write small scripts which users can run through the fil
 	<screenshot>https://raw.githubusercontent.com/Raudius/files_scripts/master/screenshots/4.png</screenshot>
 
     <dependencies>
-        <nextcloud min-version="28" max-version="28"/>
+        <nextcloud min-version="28" max-version="29"/>
 		<php min-version="8.0" />
     </dependencies>
 	<commands>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "files_scripts",
 	"description": "Nextcloud app for running custom scripts on files.",
-	"version": "4.0.3",
+	"version": "4.1.0",
 	"author": "Raul Ferreira Fuentes <r.ferreira.fuentes@gmail.com>",
 	"homepage": "https://github.com/",
 	"license": "agpl",


### PR DESCRIPTION
### Added
- Nextcloud 29 support
- Option to add inputs to occ actions (@ZeiTee)
- Button to duplicate a file action

### Fixed
- Retrieval of nodes inside group-folders for flow actions (@ZeiTee)
- Prevent creation of deleted nodes during flow action setup
