### PR TITLE
Fix ensure log function honor submitted level

### DIFF
--- a/lib/Interpreter/Functions/Output/Log.php
+++ b/lib/Interpreter/Functions/Output/Log.php
@@ -27,7 +27,7 @@ class Log extends RegistrableFunction {
 		}
 
 		$level = is_int($level) ? $level : 1;
-		$level = max(min($level, 0), 4);
+		$level = ($level >= 0 && $level <= 4) ? $level : 4;
 		$context = is_array($context) ? $context : [];
 
 		$this->logger->log($level, $message, $context);


### PR DESCRIPTION
Ensure `log`  function honors the loglevel submitted and if not matching any  level fallback to FATAL (4)

**Issue:**

* the `max(min($level, 0), 4);` always evaluates  to level 4 
```
{"reqId":"llSysqt5s7P2grK1DKUB","level":4,"time":"2024-08-23T22:04:42+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: info blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"llSysqt5s7P2grK1DKUB","level":4,"time":"2024-08-23T22:04:42+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: warn blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"llSysqt5s7P2grK1DKUB","level":4,"time":"2024-08-23T22:04:42+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: error blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"llSysqt5s7P2grK1DKUB","level":4,"time":"2024-08-23T22:04:42+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: debug blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"llSysqt5s7P2grK1DKUB","level":4,"time":"2024-08-23T22:04:42+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: fatal blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
```

I think this is unintended and shall set a sain default if none of the submitted level values matches.

**Fix:**

```
{"reqId":"FU31KBYHMysQZPDWe68f","level":1,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: info blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"FU31KBYHMysQZPDWe68f","level":2,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: warn blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"FU31KBYHMysQZPDWe68f","level":3,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: error blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"FU31KBYHMysQZPDWe68f","level":0,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: debug blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"FU31KBYHMysQZPDWe68f","level":4,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: fatal blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"FU31KBYHMysQZPDWe68f","level":4,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: log_higher (10) blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
{"reqId":"FU31KBYHMysQZPDWe68f","level":4,"time":"2024-08-23T22:08:14+00:00","remoteAddr":"","user":"--","app":"files_scripts","method":"","url":"--","message":"set_date_as_tag: log_lower (-10) blubber","userAgent":"--","version":"29.0.5.1","data":{"app":"files_scripts"}}
``` 

The fix will set level 4 (FATAL) if it is not between `0..4`


**Simple Lua Test Script:**


```
local script_name = "set_date_as_tag: "

----------------------------------------------------------------
-- LOGGING FUNCTIONS
-- 0: DEBUG: All activity; the most detailed logging.
-- 1: INFO:  Activity such as user logins and file activities, plus warnings, errors, and fatal errors.
-- 2: WARN:  Operations succeed, but with warnings of potential problems, plus errors and fatal errors.
-- 3: ERROR: An operation fails, but other services and operations continue, plus fatal errors.
-- 4: FATAL: The server stops.
----------------------------------------------------------------
function log_debug(message)
  log(script_name .. message, 0)
end

function log_info(message)
  log(script_name .. message, 1)
end

function log_warn(message)
  log(script_name .. message, 2)
end

function log_error(message)
  log(script_name .. message, 3)
end

function log_fatal(message)
  log(script_name .. message, 4)
end

function log_higher(message)
  log(script_name .. message, 10)
end

function log_lower(message)
  log(script_name .. message, -10)
end

----------------------------------------------------------------
-- MAIN
----------------------------------------------------------------
log_info("info blubber")
log_warn("warn blubber")
log_error("error blubber")
log_debug("debug blubber")
log_fatal("fatal blubber")
log_higher("log_higher (10) blubber")
log_lower("log_lower (-10) blubber")

```

