### PR TITLE
Mustache Escaping Flag

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -614,9 +614,11 @@ This function has been removed. The dependency that makes this function work is 
 You can continue using the function by manually installing the [`files_scripts_deprecated`](https://github.com/Raudius/files_scripts_deprecated) app, which bundles all the removed functions.
 ### mustache
 
-`mustache(String template, [Table variables]={}): String`  
+`mustache(String template, [Table variables]={}, [Bool escape]=true): String`  
   
-Renders a [mustache](https://mustache.github.io) template.  
+Renders a [mustache](https://mustache.github.io) template.
+If escape is false, no escaping of special characters (for e.g. HTML) will be performed. This is suitable for use with plaintext or other file formats where no special handling is desired.
+
 Returns the resulting string.
 ## Util
 ### create_date_time

--- a/lib/Interpreter/Functions/Template/Mustache.php
+++ b/lib/Interpreter/Functions/Template/Mustache.php
@@ -12,12 +12,19 @@ use OCA\FilesScripts\Interpreter\RegistrableFunction;
  * Returns the resulting string.
  */
 class Mustache extends RegistrableFunction {
-	public function run($template = '', $vars = []): string {
+	public function run($template = '', $vars = [], $escape = false): string {
 		if (!$vars || !is_array($vars)) {
 			$vars = [];
 		}
 		$vars = $this->normaliseArray($vars);
 
-		return (new Mustache_Engine(['entity_flags' => ENT_QUOTES]))->render($template, $vars);
+		$options = $escape ? [
+			'entity_flags' => ENT_QUOTES
+		] : [
+			'escape' => function($value) { return $value; }
+		];
+
+		return (new Mustache_Engine($options))->render($template, $vars);
+
 	}
 }


### PR DESCRIPTION
Add boolean parameter to mustache to control whether escaping of special characters is performed or not.

I am working with plain files, YAML, etc., and the HTML escaping that the Mustache_Engine is set up with causes problems here.

It might be desirable to expose further finetuning instead of making it a boolean, leave that up to you.

I've done basic tests but not written any testcases etc.